### PR TITLE
Add ADR0001: Repository Split

### DIFF
--- a/doc/arch/adr-0001-repo-split.md
+++ b/doc/arch/adr-0001-repo-split.md
@@ -1,0 +1,5 @@
+# Repository Split
+
+This ADR describes the reasoning behind splitting the ICELI PlanIt application source code from the Azavea [Climate API](https://climate.azavea.com).
+
+See [ADR 0008](https://github.com/azavea/climate-change-api/blob/develop/doc/arch/adr-0008-repo-split.rst) in the azavea/climate-change-api repository.


### PR DESCRIPTION
## Overview

Provide a link to the Climate API repo split ADR as 0001 for this repo so that it can be easily referenced.

Trivial, merging.