### PR TITLE
Get Django settings from environment

### DIFF
--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
 ENVIRONMENT = os.getenv('DJANGO_ENV')
 
-LOGLEVEL = os.getenv('DJANGO_LOG_LEVEL')
+LOGLEVEL = os.getenv('DJANGO_LOG_LEVEL', 'INFO')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = (ENVIRONMENT == 'development')
@@ -128,3 +128,21 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# LOGGING CONFIGURATION
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': LOGLEVEL
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Read environment variables for environment, log level, and database settings.
Also switch from using default SQLite DB to PostGIS backend.


## Testing Instructions

 * Rebuild Django container
 * Recreate superuser
 * Should still be able to access and log in to admin site


Closes #13.
