### PR TITLE
Add PostgreSQL service health check

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -5,6 +5,6 @@ aws_profile: "climate"
 aws_cli_version: "1.11.145"
 
 docker_version: "17.*"
-docker_compose_version: "1.15.0"
+docker_compose_version: "1.16.1"
 
 shellcheck_version: "0.3.*"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   terraform:
     image: "quay.io/azavea/terraform:0.9.11"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   django:
     image: "planit-app:${GIT_COMMIT:-latest}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   database:
     image: quay.io/azavea/postgis:2.2-postgres9.5-slim
@@ -6,9 +6,21 @@ services:
       - POSTGRES_USER=planit
       - POSTGRES_PASSWORD=planit
       - POSTGRES_DB=planit
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 3s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
 
   django:
     image: planit-app
+    build:
+      context: ./src/django
+      dockerfile: Dockerfile
+    depends_on:
+      database:
+        condition: service_healthy  
     environment:
       - POSTGRES_HOST=database.service.planit.internal
       - POSTGRES_PORT=5432
@@ -20,9 +32,6 @@ services:
       - DJANGO_SECRET_KEY=secret
       - DJANGO_LOG_LEVEL=INFO
       - AWS_PROFILE=planit
-    build:
-      context: ./src/django
-      dockerfile: Dockerfile
     command:
       - "--workers=2"
       - "--timeout=60"

--- a/scripts/update
+++ b/scripts/update
@@ -21,19 +21,24 @@ then
         usage
     else
         # Build the Django container image.
-        docker-compose \
-            -f docker-compose.yml \
-            build django
+        docker-compose build django
+
+        # Bring up PostgreSQL and Django in a way that respects
+        # configured service health checks.
+        docker-compose up -d database django
 
         # Apply any outstanding migrations.
         docker-compose \
-            -f docker-compose.yml \
             run --rm --entrypoint python \
             django manage.py migrate --noinput
 
+        # Remove Django service associated with `docker-compose up`
+        # command above.
+        docker-compose kill django \
+            && docker-compose rm -f django
+
         # Collect static files
         docker-compose \
-            -f docker-compose.yml \
             run --rm --entrypoint python \
             django manage.py collectstatic
     fi


### PR DESCRIPTION
## Overview

When setting up the project for the first time, `update` can sometimes attempt to apply database migrations before the PostgreSQL database has been initialized. This change set adds a `pg_isready` health check other services can depend on. In this case, the Django service is configured to depend on the database being in a health state before it attempts to apply migrations.

This also downgrades the PostgreSQL/PostGIS container image to 9.5 (from 9.6) because we are depending on the same RDS infrastructure that supports the Climate API (which is running PostgreSQL 9.5).

## Testing Instructions

**Note**: This will wipe your database contents.

From inside of the Vagrant virtual machine, wipe all of the running containers and run `update`:

```bash
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ docker ps -qa | xargs -r docker rm -f
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/update
```

The `django` container should wait for PostgreSQL to fully initialize before attempting to apply migrations.

Closes #27 
