### PR TITLE
Add AWS deployment support to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,16 @@ node {
                     }
                 }
             }
+
+            // Plan and apply the current state of the instracture as
+            // outlined by the `develop` branch of the `climate-planit`
+            // repository.
+            stage('infra') {
+                wrap([$class: 'AnsiColorBuildWrapper']) {
+                    sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+                    sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                }
+            }
         }
     } catch (err) {
         // Some exception was raised in the `try` block above. Assemble


### PR DESCRIPTION
## Overview

Add an `infra` stage to the current `Jenkinsfile` so that it executes the `infra` STRTA script within the context of the appropriate Terraform container image.

## Testing Instructions

See Jenkins [output](http://urbanappsci.internal.azavea.com/job/azavea/job/climate-planit/job/feature%252Fhmc%252Fjenkinsfile-infra/1/console) when this branch was temporarily whitelisted.

Closes #53 