### PR TITLE
Set default angular CLI host and port

### DIFF
--- a/src/angular/planit/.angular-cli.json
+++ b/src/angular/planit/.angular-cli.json
@@ -51,8 +51,12 @@
     }
   },
   "defaults": {
+    "poll": 1000,
     "styleExt": "scss",
     "component": {},
+    "build": {
+      "poll": 1000
+    },
     "serve": {
       "port": 4210,
       "host": "0.0.0.0"


### PR DESCRIPTION
Fixes angular container setup to be visible from host when running `./scripts/server` within VM.

Match angular server port to that exposed to host (default is 4200).
Also set angular host to 0.0.0.0 for serving from within VM (default is localhost).

In #62 the exposed port for the `angular` container is set to 4210, but the angular CLI server runs on port 4200 by default. It's also necessary to change the host for serving from within a VM (the lab project does [something similar](https://github.com/azavea/climate-change-lab/blob/develop/package.json#L15). Now `.angular-cli.json` is available to set port and host default configuration, so sending command-line arguments within the `package.json` is no longer necessary.

![image](https://user-images.githubusercontent.com/960264/30868022-801bd20a-a2ab-11e7-942d-779feb047926.png)

