### PR TITLE
Pass POSTGRES_USER to docker-compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_PASSWORD=planit
       - POSTGRES_DB=planit
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD", "pg_isready", "-U", "planit"]
       interval: 3s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Overview

Include `POSTGRES_USER` in healthcheck command. Removes error messages from the `database` container that say `FATAL: role "root" does not exist`.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

I switched from an `exec` array to shell syntax because the quotes were making `docker-compose`  pull `POSTGRES_USER` from the vagrant environment (where it is not set). Using shell syntax makes it clear that `${POSTGRES_USER}` should be evaluated within the container's shell.


## Testing Instructions
***THIS WILL REQUIRE YOU TO RECREATE YOUR DATABASE***
- Remove all containers and volumes with `docker-compose down -v`.
- Do `docker-compose up database`, ensure that the log stream contains no errors.

Closes #57 