### PR TITLE
Setup stub global sass file/directory, add Bootstrap

### DIFF
--- a/src/angular/planit/.angular-cli.json
+++ b/src/angular/planit/.angular-cli.json
@@ -19,7 +19,7 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "styles.scss"
+        "assets/sass/main.scss"
       ],
       "scripts": [],
       "environmentSource": "environments/environment.ts",

--- a/src/angular/planit/package-lock.json
+++ b/src/angular/planit/package-lock.json
@@ -873,6 +873,16 @@
         "hoek": "4.2.0"
       }
     },
+    "bootstrap": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+    },
+    "bootstrap-sass": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -4864,6 +4874,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "ngx-bootstrap": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
+      "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
     },
     "no-case": {
       "version": "2.3.2",

--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -24,7 +24,10 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
+    "bootstrap": "^3.3.7",
+    "bootstrap-sass": "^3.3.7",
     "core-js": "^2.4.1",
+    "ngx-bootstrap": "^1.9.3",
     "rxjs": "^5.4.2",
     "zone.js": "^0.8.14"
   },

--- a/src/angular/planit/src/assets/sass/_bootstrap.scss
+++ b/src/angular/planit/src/assets/sass/_bootstrap.scss
@@ -1,0 +1,26 @@
+/*!
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+// Core variables and mixins
+@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/mixins";
+
+// Reset and dependencies
+@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/print";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
+
+// Core CSS
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/type";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/code";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/grid";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/tables";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/forms";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/buttons";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
+//@import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/dropdowns";

--- a/src/angular/planit/src/assets/sass/main.scss
+++ b/src/angular/planit/src/assets/sass/main.scss
@@ -1,0 +1,3 @@
+/* TODO: Copy prototype SCSS as part of #40 */
+
+@import 'bootstrap';

--- a/src/angular/planit/src/styles.scss
+++ b/src/angular/planit/src/styles.scss
@@ -1,1 +1,0 @@
-/* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
## Overview

 - Adds a `assets/sass` directory with a `main.scss` for global styles, replacing the `styles.scss` in the Angular root directory. `main.scss` is currently a stub, with styling to be moved from the
prototypes as part of #40
 - Adds `bootstrap-sass` & `ngx-bootstrap`