### PR TITLE
Add Django Debug Toolbar in development

### DIFF
--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -91,6 +92,18 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
 ]
+
+# Django Debug Toolbar
+if DEBUG:
+    INSTALLED_APPS += [
+        'debug_toolbar',
+    ]
+    INTERNAL_IPS = [
+        '10.0.2.2',
+        '0.0.0.0',
+        '127.0.0.1',
+        'localhost',
+    ]
 
 if not DEBUG:
     ROLLBAR = {

--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -34,3 +34,9 @@ urlpatterns = [
 
 if settings.ENVIRONMENT == 'development':
     urlpatterns += staticfiles_urlpatterns()
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
## Overview

Adds debug toolbar to ease dev workflow. Only enabled in debug as per the [DDT docs](https://django-debug-toolbar.readthedocs.io/en/stable/tips.html#the-toolbar-isn-t-displayed).

### Demo

![screen shot 2017-10-05 at 13 26 09](https://user-images.githubusercontent.com/1818302/31241195-2ce537d4-a9d1-11e7-92df-bcdc37ecaf7d.png)

## Testing Instructions

It turns out the package was already installed, just not configured in settings.py. So refreshing localhost:8100 after checking out the branch should suffice to display the toolbar.

Closes #95 
