### PR TITLE
Update Jenkinsfile & testing scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,19 @@ node {
         stage('cibuild') {
             wrap([$class: 'AnsiColorBuildWrapper']) {
                 sh 'scripts/cibuild'
+
+                step([$class: 'WarningsPublisher',
+                    parserConfigurations: [[
+                        parserName: 'JSLint',
+                        pattern: 'src/angular/planit/violations.xml'
+                    ], [
+                        parserName: 'Pep8',
+                        pattern: 'src/django/violations.txt'
+                    ]],
+                    // mark build unstable if there are any linter warnings
+                    unstableTotalAll: '0',
+                    usePreviousBuildAsReference: true
+                ])
             }
         }
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -25,10 +25,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f docker-compose.yml \
                   -f docker-compose.test.yml \
-                  build django
+                  build django angular
 
         echo "Running tests"
-        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
+        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test --jenkins
         echo "All tests pass!"
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -9,9 +9,10 @@ fi
 GIT_COMMIT="${GIT_COMMIT:-latest}"
 
 function usage() {
-    echo -n \
+    echo -ne \
          "Usage: $(basename "${0}")
 Run linters and tests.
+--jenkins \tAlso run linter with file output for Jenkins CI server to parse.
 "
 }
 
@@ -23,14 +24,43 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             find ./scripts -maxdepth 1 -type f -print0 | xargs -0 shellcheck
         fi
 
+        if [ "${1:-}" = "--jenkins" ]; then
+            FLAKE8_ARGS="--output-file=violations.txt"
+            ANGULAR_LINT_CMD="lint:ci"
+        else
+            FLAKE8_ARGS=""
+            ANGULAR_LINT_CMD="lint"
+        fi
+
+        # Python Lint
+        # Need to remove file before running, as flake8 won't remove
+        # old violations from it if there are no violations now
+        set +e
+        echo "Remove linter output file, if present"
+        docker-compose \
+            run --rm --entrypoint "rm" \
+            django violations.txt
+        set -e
+
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f docker-compose.yml \
                   -f docker-compose.test.yml \
                   run --rm --entrypoint flake8 \
-                  django --exit-zero --exclude planit/migrations .
+                  django --exit-zero --tee "$FLAKE8_ARGS"
 
-        sleep 3
+        # Angular Lint
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                  -f docker-compose.yml \
+                  -f docker-compose.test.yml \
+                  run --rm angular npm run "$ANGULAR_LINT_CMD"
 
+        # Angular Tests
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                  -f docker-compose.yml \
+                  -f docker-compose.test.yml \
+                  run --rm angular npm run test
+
+        # Python Tests
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f docker-compose.yml \
                   -f docker-compose.test.yml \

--- a/src/angular/Dockerfile
+++ b/src/angular/Dockerfile
@@ -1,5 +1,15 @@
 FROM node:6-slim
 
+
+# Install Chrome for running ng test
+RUN set -ex \
+    && apt-get update -yq \
+    && karmaDeps=' \
+        g++ \
+        chromium \
+    ' \
+    && apt-get install -y ${karmaDeps}
+
 WORKDIR /opt/planit/angular/planit
 
 COPY ./planit/package.json /opt/planit/angular/planit/

--- a/src/angular/planit/karma.conf.js
+++ b/src/angular/planit/karma.conf.js
@@ -27,7 +27,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['ChromeHeadless'],
+    singleRun: true,
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chromium',
+        flags: ['--no-sandbox', '--disable-gpu', '--headless', '--remote-debugging-port=9222']
+      }
+    }
   });
 };

--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -8,7 +8,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint --type-check",
-    "lint:ci": "ng lint --type-check --format checkstyle > jenkins/violations.xml",
+    "lint:ci": "ng lint --type-check --force --format checkstyle > violations.xml",
     "e2e": "ng e2e",
     "build:prod": "ng build -prod --aot --extract-css",
     "postinstall": "npm rebuild node-sass"

--- a/src/django/planit_data/tests.py
+++ b/src/django/planit_data/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/src/django/planit_data/views.py
+++ b/src/django/planit_data/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/src/django/setup.cfg
+++ b/src/django/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 ignore = D100,D101,D102,D103,D104
 max-line-length = 100
-exclude = migrations
+exclude = migrations,manage.py
 max-complexity = 15

--- a/src/django/users/tests.py
+++ b/src/django/users/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/src/django/users/views.py
+++ b/src/django/users/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.


### PR DESCRIPTION
## Overview

Add Angular lint & test to test script, report violations on Jenkins.

## Notes

 - Fixes Python lint (mostly imports in files that have yet to be filled out)
 - Excludes manage.py from linting
 - Adds --jenkins flag to scripts/test, report violations when it is passed
 - Checks Angular lint & tests in scripts/test
 - Report lint warnings to Jenkins WarningsPlugin
 - Only mark build unstable if `ng lint` fails (instead of failing)

## Testing Instructions
 - `./scripts/update`
 - Ensure the `scripts/test` script continues to function properly
 - Ensure Jenkins PR testing behavior is correct

Closes #68