### PR TITLE
Fix Angular development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: ./src/angular
       dockerfile: Dockerfile
     volumes:
-      - ./src/angular:/opt/planit/angular
+      - ./src/angular/planit/src:/opt/planit/angular/planit/src
     ports:
       - "4210:4210"
 

--- a/scripts/update
+++ b/scripts/update
@@ -25,12 +25,6 @@ then
             -f docker-compose.yml \
             build angular
 
-        # npm install
-        docker-compose \
-            -f docker-compose.yml \
-            run --rm --entrypoint "/bin/bash -c" \
-            angular "npm install"
-
         # Build the Django container image.
         docker-compose build django
 

--- a/src/angular/Dockerfile
+++ b/src/angular/Dockerfile
@@ -1,14 +1,9 @@
-FROM node:8.5.0-wheezy
+FROM node:6-slim
 
-MAINTAINER Azavea
+WORKDIR /opt/planit/angular/planit
 
-ENV PLANIT_NG_DIR /opt/planit/angular/planit/
-
-RUN apt-get update && apt-get install -y rsync \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR ${PLANIT_NG_DIR}
-COPY ./planit/ ${PLANIT_NG_DIR}
-RUN npm install
+COPY ./planit/package.json /opt/planit/angular/planit/
+RUN npm install && npm cache clean --force
+COPY ./planit/ /opt/planit/angular/planit
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Overview

Work toward an approach where all of the Node dependencies are encapsulated by the container image. While building the image, use changes to `package.json` as a way to indicate that the image needs rebuilding.

For development, only volume mount the `src` directory inside of the Angular project. This avoids volume mounting on top of files or directories that were created as part of the image building process.

### Notes

 This change likely makes it more difficult to see changes made to files outside of the `src` directory, but it looks like that may be an acceptable trade-off. Changes made to files outside of `src` will require a container image rebuild via `update`.

## Testing Instructions

I tested these changes with a clean checkout of `develop` (ran `git clean -fdX` after destroying my Vagrant virtual machine because the command above can wipe out `.vagrant` if you don't have it excluded):

```bash
$ ./scripts/setup
$ vagrant ssh
$ ./scripts/server
```

From there, I viewed the app via http://localhost:4210/. After confirming it was up, I made a change to `index.html` by updating the `title` tag, which was picked up automatically by Webpack and caused my page to reload with the changes present.

Fixes #97 