### PR TITLE
Add DJANGO_STATIC_HOST to app server task definition

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -70,6 +70,7 @@ data "template_file" "planit_app_https_ecs_task" {
   vars = {
     app_server_django_url            = "${data.terraform_remote_state.core.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/planit-app:${var.git_commit}"
     django_secret_key                = "${var.django_secret_key}"
+    django_static_host               = "https://${aws_route53_record.cdn.fqdn}"
     rds_host                         = "${data.terraform_remote_state.core.rds_host}"
     rds_database_name                = "${var.rds_database_name}"
     rds_username                     = "${data.terraform_remote_state.core.rds_username}"
@@ -114,6 +115,7 @@ data "template_file" "planit_app_management_ecs_task" {
   vars {
     management_url                   = "${data.terraform_remote_state.core.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/planit-app:${var.git_commit}"
     django_secret_key                = "${var.django_secret_key}"
+    django_static_host               = "https://${aws_route53_record.cdn.fqdn}"
     rds_host                         = "${data.terraform_remote_state.core.rds_host}"
     rds_database_name                = "${var.rds_database_name}"
     rds_username                     = "${data.terraform_remote_state.core.rds_username}"

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -49,6 +49,10 @@
                 "value": "${environment}"
             },
             {
+                "name": "DJANGO_STATIC_HOST",
+                "value": "${django_static_host}"
+            },
+            {
                 "name": "COMMIT",
                 "value": "${git_commit}"
             }

--- a/deployment/terraform/task-definitions/management.json
+++ b/deployment/terraform/task-definitions/management.json
@@ -51,6 +51,10 @@
                 "value": "${environment}"
             },
             {
+                "name": "DJANGO_STATIC_HOST",
+                "value": "${django_static_host}"
+            },
+            {
                 "name": "COMMIT",
                 "value": "${git_commit}"
             }


### PR DESCRIPTION
## Overview

Adds `DJANGO_STATIC_HOST` variable to the `app` and `management` task definitions so that Django knows from where to request static files. Also, update CloudFront to cache files requested from `DJANGO_STATIC_HOST/static`.

### Demo (note Request Path and CloudFront cache response)

<img width="1279" alt="screen shot 2017-10-10 at 2 07 29 pm" src="https://user-images.githubusercontent.com/2507188/31402577-64ef2d32-adc4-11e7-8978-171266527942.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Visit https://planit.climate.azavea.com with the Network tab of the JavaScript console open. Be sure all static files are served from the CloudFront cache.
 * Check the request headers to be sure that files are being requested from `/planit.climate.azavea.com/static`
