### PR TITLE
Use angular container to remove existing JS bundle

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -30,7 +30,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
           django manage.py collectstatic --noinput
 
         # Clean out existing angular bundle before build
-        docker-compose run --rm --entrypoint "bash -c" nginx "rm -rf /var/www/*"
+        docker-compose run --rm --entrypoint "bash -c" angular "rm -rf dist/*"
         docker-compose run --rm angular run build --delete-output-path false
 
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \

--- a/scripts/update
+++ b/scripts/update
@@ -47,7 +47,7 @@ then
             && docker-compose rm -f django
 
         # Build AngularJS bundle for use with nginx
-        docker-compose run --rm --entrypoint "bash -c" nginx "rm -rf /var/www/*"
+        docker-compose run --rm --entrypoint "bash -c" angular "rm -rf dist/*"
         docker-compose run --rm angular run build --delete-output-path false
 
         # Build Nginx


### PR DESCRIPTION
## Overview

Currently, when running `scripts/update` or `scripts/cibuild`, we attempt to delete any existing AngularJS bundles at `nginx/dist`. Using the nginx container triggers a build (since the container hasn't been built yet), which fails [here](https://github.com/azavea/temperate/blob/develop/nginx/Dockerfile#L5) because `dist/` doesn't exist. This PR removes existing files using the `angular` container instead.
### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * See Jenkins build output for this PR.
 * In development, delete `nginx/dist` manually, run `docker-compose down -v` to remove any existing `nginx` images, then run `scripts/update`.


