### PR TITLE
Prevent silent deletion of dist folder

### DIFF
--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --delete-output-path false",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint --type-check",


### PR DESCRIPTION
See: https://github.com/angular/angular-cli/issues/6375

## Overview

`./scripts/server --angular` was failing to come up due to  angular silently deleting a `/dist` folder upon `ng serve`. The problem is we reference/use this folder mounting in nginx, so we need to prevent deleting it.

## Testing Instructions

See the error by running `./scripts/server --angular`
To test this PR:
`docker-compose rebuild angular`
`./scripts/server --angular`

