### PR TITLE
Add route for static files to development URL config.

### DIFF
--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.conf import settings
 from django.contrib import admin
+from django.conf.urls.static import static
 
 from rest_framework import routers
 
@@ -42,4 +43,4 @@ if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
-    ]
+    ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview

In #126, I replaced Django's static file server with nginx. Because of this, django no longer has a route to static files, which means that they aren't served via Gunicorn in development. This PR adds a path to static files to `urlpatterns` in development.

See See https://docs.djangoproject.com/en/1.11/howto/static-files/#serving-static-files-during-development

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Run `scripts/server`, and make sure static files are available at http://localhost:8100/admin

Closes #139 
