### PR TITLE
Closes #116: Set current class via routerLinkActive

### DIFF
--- a/src/angular/planit/src/app/shared/sidebar/sidebar.component.html
+++ b/src/angular/planit/src/app/shared/sidebar/sidebar.component.html
@@ -1,8 +1,8 @@
 <nav class="primary-nav-container" role="banner">
     <ul class="primary-nav">
-        <li class="list-item current"
+        <li class="list-item"
             *ngFor="let tab of tabs">
-            <a class="link" routerLink="/{{tab | lowercase}}">{{ tab }}</a>
+            <a class="link" routerLink="/{{tab | lowercase}}" routerLinkActive="current">{{ tab }}</a>
         </li>
     </ul>
 </nav>

--- a/src/angular/planit/src/assets/sass/components/_navigation-primary.scss
+++ b/src/angular/planit/src/assets/sass/components/_navigation-primary.scss
@@ -11,8 +11,17 @@
   list-style-type: none;
   padding: 0.25rem 2rem;
 
-  &.current {
-    .link:before {
+  .link {
+    font-size: $text-base;
+    color: $gray-5;
+    margin: 0;
+    padding: 0.5rem 2rem;
+    text-decoration: none;
+    border-radius: $button-border-radius;
+    position: relative;
+    display: block;
+
+    &.current:before {
       content: "";
       display: block;
       width: 6px;
@@ -24,17 +33,6 @@
       background-color: $brand-primary;
       border-radius: 3px;
     }
-  }
-
-  .link {
-    font-size: $text-base;
-    color: $gray-5;
-    margin: 0;
-    padding: 0.5rem 2rem;
-    text-decoration: none;
-    border-radius: $button-border-radius;
-    position: relative;
-    display: block;
 
     &:hover, &.hover,
     &:active, &.active, {


### PR DESCRIPTION
## Overview

Set current class via routerLinkActive


### Demo

<img width="695" alt="screen shot 2017-10-23 at 20 15 39" src="https://user-images.githubusercontent.com/1818302/31919235-f8d4ce52-b82e-11e7-8e2a-10f2319f6bf2.png">

### Notes

I moved the definition of the `.current` class so that it must be on the same element as a `.link` class because we cannot cleanly add a routerLinkActive directive to an element that is a parent of the element where routerLink is defined.

## Testing Instructions

 * Go to Dashboard. Ensure that the active dot only displays on the sidebar route that is active.

Closes #116 
