### PR TITLE
Use django_amazon_ses email backend in non-dev environments

### DIFF
--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -188,18 +188,21 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+
+# Email Settings
+if ENVIRONMENT == 'Development':
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+else:
+    EMAIL_BACKEND = 'django_amazon_ses.backends.boto.EmailBackend'
+
+DEFAULT_FROM_EMAIL = 'noreply@temperate.io'
+DEFAULT_TO_EMAIL = 'support@temperate.io'
+
+
 # Django-Registration
 ACCOUNT_ACTIVATION_DAYS = 14
 REGISTRATION_OPEN = True
 AUTH_PROFILE_MODULE = 'registration.RegistrationProfile'
-
-# TODO: #134 set up staging/production email
-# set to 'django_amazon_ses.backends.boto.EmailBackend' if not DEBUG
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-DEFAULT_FROM_EMAIL = os.getenv('CC_FROM_EMAIL', 'noreply@climate.azavea.com')
-DEFAULT_TO_EMAIL = os.getenv('CC_TO_EMAIL', 'climate@azavea.com')
-COMPANY_DOMAIN = '@azavea.com'
 
 
 # Internationalization

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,5 +1,6 @@
 django-bootstrap3==9.0.0
 djangorestframework==3.7.0
+django-amazon-ses==0.3.0
 django-debug-toolbar==1.8
 django-extensions==1.9.1
 django-registration==2.3


### PR DESCRIPTION
## Overview

Use django_amazon_ses email backend in AWS environments

### Demo

I got as far as having the application throw a "missing profile 'planit'" error by manually setting email backend to django_amazon_ses to ensure it was configured correctly.
```
from django.core.mail import send_mail
from django.conf import settings
send_mail('test', 'test message', settings.DEFAULT_FROM_EMAIL, ['afink@azavea.com'])

---------------------------------------------------------------------------
ProfileNotFound                           Traceback (most recent call last)
<ipython-input-3-fd766aaf7248> in <module>()
----> 1 send_mail('test', 'test message', settings.DEFAULT_FROM_EMAIL, ['afink@azavea.com'])
```

If you then setup a `planit` profile with appropriate credentials:
![screen shot 2017-10-26 at 11 55 10](https://user-images.githubusercontent.com/1818302/32063246-aa903548-ba44-11e7-97c6-8214ccb29ca3.png)

I setup my planit profile, then:

![screen shot 2017-10-26 at 11 55 10](https://user-images.githubusercontent.com/1818302/32064631-6265f4fc-ba48-11e7-8761-1cf2a9ff6f7c.png)


## Notes

- I did not add instructions to setup an AWS `planit` profile in development as its not necessary since development emails still use the console backend. If you happen to have one set up, messages should send from dev via SES if you force the SES backend in dev
- I sent two messages after configuring credentials, and didn't receive them. It's unclear from the SES metrics charts in the console whether AWS ever received or sent or bounced the message.
- Updated DEFAULT_FROM_EMAIL to `noreply@temperate.io` as noted in the issue, agree that that's fine for now.
- Updated DEFAULT_TO_EMAIL to `support@temperate.io`, this address is used for contact us links in the app.
- Removed COMPANY_DOMAIN, its not in use anywhere in the project as far as I can tell.


## Testing Instructions
 * Rebuild container with `./scripts/update`
 * Ensure console emails still work in dev, either by [registering a new account](http://localhost:8100/accounts/register) or by sending one via a Django shell
 * Manually set the EMAIL_BACKEND to django_amazon_ses for all environments by modifying settings, then send a manual email and ensure a auth exception is thrown

Closes #134
