### PR TITLE
Add missing ref to ccapi_host in ECS HTTPS app task

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -117,6 +117,7 @@ data "template_file" "planit_app_https_ecs_task" {
     aws_region                       = "${var.aws_region}"
     ccapi_email                      = "${var.ccapi_email}"
     ccapi_password                   = "${var.ccapi_password}"
+    ccapi_host                       = "${var.ccapi_host}"
   }
 }
 


### PR DESCRIPTION
## Overview

Fixes a missing variable ref in the terraform deployment for ccapi_host. Going to merge, already tested that infra/plan and infra/apply work locally.

