### PR TITLE
Remove token field from UserSerializer

### DIFF
--- a/src/django/users/serializers.py
+++ b/src/django/users/serializers.py
@@ -51,7 +51,6 @@ class UserSerializer(serializers.ModelSerializer):
         Retrieves token if available for a user, or returns ``null``
     """
 
-    token = serializers.SerializerMethodField()
     isActive = serializers.BooleanField(source='is_active', default=False, read_only=True)
     firstName = serializers.CharField(source='first_name', allow_blank=False, required=True)
     lastName = serializers.CharField(source='last_name', allow_blank=False, required=True)
@@ -69,14 +68,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = PlanItUser
         fields = ('id', 'email', 'isActive', 'firstName', 'lastName', 'organizations',
-                  'password1', 'password2', 'token')
-
-    def get_token(self, obj):
-        try:
-            token = Token.objects.get(user=obj)
-            return token.key
-        except Token.DoesNotExist:
-            return None
+                  'password1', 'password2',)
 
     def validate(self, data):
         # check passwords match


### PR DESCRIPTION
## Overview

Was looking at staging in preparation for RRP and was getting 500 errors on requests to `/api/users/` due to Token.DoesNotExist in the UserSerializer.get_token() method. Fixed it up, but then figured its probably better to not expose a user's token to all users.

### Demo

`/api/users/` works again, sans token property:
![screen shot 2017-11-02 at 08 52 46](https://user-images.githubusercontent.com/1818302/32326977-3ec73200-bfab-11e7-8e98-fe17744fdc54.png)


## Testing Instructions

 * User list should work. Other User HTTP API actions should remain unaffected.
