### PR TITLE
Fix ng lint whitespace error

### DIFF
--- a/src/angular/planit/src/app/indicators/indicators.component.ts
+++ b/src/angular/planit/src/app/indicators/indicators.component.ts
@@ -9,7 +9,6 @@ export class IndicatorsComponent implements OnInit {
 
   public allIndicators: any[];
 
-
   constructor() {
 
     // test copy for accordion of collapsible cards of all indicators
@@ -27,16 +26,15 @@ export class IndicatorsComponent implements OnInit {
   ngOnInit() {
   }
 
-  public addTopConcern(concern: any):void {
+  public addTopConcern(concern: any) {
     console.log(concern);
   }
 
-  public collapsed(event: any):void {
+  public collapsed(event: any) {
     console.log(event);
   }
 
-  public expanded(event: any):void {
+  public expanded(event: any) {
     console.log(event);
   }
-
 }


### PR DESCRIPTION
## Overview

Fixes whitespace error causing all jenkins builds to fail and cleans up some unnecessary type declarations.

### Notes

I just removed the `: void` return type declarations rather than add the space. General TypeScript conventions is to only add types where they cannot be inferred. @maurizi and @fungjj92 for awareness.

## Testing Instructions

`./scripts/test` should now succeed.
