### PR TITLE
Add dockerignore for angular container

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -14,21 +14,12 @@ Builds and pulls container images using docker-compose.
 "
 }
 
-DIR=$(dirname ${0})
-
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ "${1:-}" = "--help" ]
     then
         usage
     else
-
-        # Make sure there's no node_modules folder on the host,
-        # or it will be included in the angular image
-        if [ -d "${DIR}/../src/angular/planit/node_modules" ];
-        then
-            rm -rf "${DIR}/../src/angular/planit/node_modules"
-        fi
 
         # Build the angular container image.
         docker-compose \

--- a/src/angular/.dockerignore
+++ b/src/angular/.dockerignore
@@ -1,0 +1,1 @@
+planit/node_modules


### PR DESCRIPTION
## Overview

Rather than adding logic to `scripts/update` to delete files that shouldn't be added to the `angular` container, add a `.dockerignore` file.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
* Create `node_modules/test-file.txt` on your host machine
* Run `docker-compose build angular`
* Ensure `node_modules/test-file.txt` isn't included in the container

```bash
$ mkdir src/angular/planit/node_modules
$ touch src/angular/planit/node_modules/test-file.txt
$ docker-compose build angular
$ docker-compose run --rm --entrypoint bash angular -c "ls node_modules/" | grep test-file.txt
```

Closes #XXX
