### PR TITLE
Feature/kak/allow nfs disable#187

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,20 @@
 
 Vagrant.require_version ">= 1.8"
 
-MOUNT_OPTIONS = if Vagrant::Util::Platform.linux? then
-                  ['rw', 'vers=3', 'tcp', 'nolock']
-                else
-                  ['vers=3', 'udp']
-                end
+TEMPERATE_SHARED_FOLDER_TYPE = ENV.fetch("TEMPERATE_SHARED_FOLDER_TYPE", "nfs")
+if TEMPERATE_SHARED_FOLDER_TYPE == "nfs"
+  if Vagrant::Util::Platform.linux? then
+    TEMPERATE_MOUNT_OPTIONS = ['rw', 'vers=3', 'tcp', 'nolock']
+  else
+    TEMPERATE_MOUNT_OPTIONS = ['vers=3', 'udp']
+  end
+else
+  if ENV.has_key?("TEMPERATE_MOUNT_OPTIONS")
+    TEMPERATE_MOUNT_OPTIONS = ENV.fetch("TEMPERATE_MOUNT_OPTIONS").split
+  else
+    TEMPERATE_MOUNT_OPTIONS = ["rw"]
+  end
+end
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
@@ -15,7 +24,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
   # Need to use NFS else Vagrant locks up on OSX
-  config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: MOUNT_OPTIONS
+  config.vm.synced_folder ".", "/vagrant", type: TEMPERATE_SHARED_FOLDER_TYPE, mount_options: TEMPERATE_MOUNT_OPTIONS
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 2048


### PR DESCRIPTION
## Overview

Fix issues mounting shared files in vagrant and make shared file mount options configurable.

Possibly due to hashicorp/vagrant#5424; some note issues with mounting shared files when docker installed on the VM. Switching to v3 of NFS or letting vagrant use defaults both solved issue on Ubuntu 17.10.

## Testing Instructions

 * Should be able to start/reload VM
 * Should be able to set `TEMPERATE_SHARED_FOLDER_TYPE` and `TEMPERATE_MOUNT_OPTIONS` to something that works for your OS and reload VM
 * Can set environment variables to empty strings to let vagrant use automatic configuration defaults

Closes #187
