### PR TITLE
Disable animation on help modal

### DIFF
--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
@@ -12,6 +12,6 @@ export class HelpModalComponent {
   constructor(private modalService: BsModalService) {}
 
   public openModal(template: TemplateRef<any>) {
-    this.modalRef = this.modalService.show(template);
+    this.modalRef = this.modalService.show(template, {animated: false});
   }
 }


### PR DESCRIPTION
## Overview

Disable animation on help modal, as we're experiencing what we believe is a bug in `ngx-bootstrap` that shows both the closing and opening animations at the same time.

### Notes

I attempted to recreate the bouncing issue we're encountering for the `ngx-bootstrap` developers, but couldn't recreate the problem in isolation on StackBlitz: https://stackblitz.com/edit/ngx-bootstrap-uoaagc

## Testing Instructions

 * `scripts/server`
 * The help modal in the nav bar should no longer bounce (or be animated at all)

Closes #149
