### PR TITLE
Add trailing slash to concern detail route

### DIFF
--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
         ClimateAPIProxyView.as_view(), name='climate-api-proxy'),
     url(r'^api/concern/$',
         planit_data_views.ConcernViewSet.as_view({'get': 'list'}), name='concern-list'),
-    url(r'^api/concern/(?P<pk>[0-9]+)$',
+    url(r'^api/concern/(?P<pk>[0-9]+)/$',
         planit_data_views.ConcernViewSet.as_view({'get': 'retrieve'}), name='concern-detail'),
     url(r'^api/weather-event-rank/$',
         planit_data_views.WeatherEventRankView.as_view(), name='weather-event-rank-list'),


### PR DESCRIPTION
### Demo

![screen shot 2017-11-20 at 14 40 56](https://user-images.githubusercontent.com/1818302/33037895-e03bb0f8-ce00-11e7-8c72-54d207ead73b.png)

## Testing Instructions

- tests should pass
- Concern detail route should resolve correctly given a trailing slash, e.g. http://localhost:8100/api/concern/1/

If you don't have a concern in your database, first create one with:
```
./scripts/manage shell_plus
> Concern.objects.create(indicator=Indicator.objects.first(), is_relative=true, tagline='This is some text')
```

Closes #185 
