### PR TITLE
Clean linter errors

### DIFF
--- a/src/django/climate_api/tests/test_views.py
+++ b/src/django/climate_api/tests/test_views.py
@@ -22,7 +22,6 @@ class ClimateAPIProxyViewTestCase(APITestCase):
     @mock.patch('climate_api.views.requests')
     def test_proxy_success(self, requests_mock):
         """Call should be made to Climate API if route passes whitelist."""
-
         def requests_mock_get(*args, **kwargs):
             response = Response()
             response.status_code = status.HTTP_200_OK

--- a/src/django/planit_data/models.py
+++ b/src/django/planit_data/models.py
@@ -16,6 +16,7 @@ class GeoRegionManager(models.Manager):
 
 class GeoRegion(models.Model):
     """A user-agnostic, arbitratry region of interest."""
+
     name = models.CharField(max_length=256, blank=False, null=False)
     geom = models.MultiPolygonField()
 
@@ -32,8 +33,8 @@ class CommunitySystem(models.Model):
     - Hospitals
     - Energy delivery
     - Food supply
-
     """
+
     name = models.CharField(max_length=256, unique=True, blank=False, null=False)
 
     def __str__(self):
@@ -47,8 +48,8 @@ class WeatherEvent(models.Model):
     - Storm surge from a hurricane
     - River flood
     - Insect infestation
-
     """
+
     name = models.CharField(max_length=256, unique=True, blank=False, null=False)
 
     def __str__(self):
@@ -59,8 +60,8 @@ class Indicator(models.Model):
     """A derived aggregate computation that provides some form of climate insight.
 
     See https://docs.climate.azavea.com/indicators.html for some concrete examples
-
     """
+
     name = models.CharField(max_length=256, unique=True, blank=False, null=False)
     label = models.CharField(max_length=512, blank=False, null=False)
     description = models.TextField(blank=True, null=False, default='')
@@ -71,10 +72,12 @@ class Indicator(models.Model):
 
 class RiskTemplate(models.Model):
     """A generic template for a Climate Risk, not attached to any particular app user.
+
     When a user requests insight about a particular location in the app, these templates
     are used to generate new user-specific UserRisk objects that the user can then
     modify directly.
     """
+
     community_system = models.ManyToManyField('CommunitySystem', related_name='risk', blank=True)
     weather_event = models.ForeignKey(WeatherEvent, null=False)
     indicator = models.ManyToManyField('Indicator', related_name='climate_risk', blank=True)
@@ -130,8 +133,8 @@ class WeatherEventRank(models.Model):
 
     This model holds the default rankings for all organizations, which are used by the
     "Top Concerns" feature of the app.
-
     """
+
     georegion = models.ForeignKey(GeoRegion, null=False)
     weather_event = models.ForeignKey(WeatherEvent)
     order = models.IntegerField()

--- a/src/django/setup.cfg
+++ b/src/django/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D100,D101,D102,D103,D104
+ignore = D100,D101,D102,D103,D104,D105
 max-line-length = 100
 exclude = migrations,manage.py
 max-complexity = 15

--- a/src/django/users/models.py
+++ b/src/django/users/models.py
@@ -35,6 +35,7 @@ class PlanItLocation(models.Model):
 
 class PlanItOrganization(models.Model):
     """Users belong to one or more organizations."""
+
     METRIC = 'METRIC'
     IMPERIAL = 'IMPERIAL'
     UNITS_CHOICES = ((IMPERIAL, 'imperial'),
@@ -62,7 +63,7 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
 
 
 class PlanItUserManager(BaseUserManager):
-    """Custom user manager, based on Django's UserManager"""
+    """Custom user manager, based on Django's UserManager."""
 
     def _create_user(self, email, first_name, last_name, password, **extra):
         if not email:
@@ -125,7 +126,7 @@ class PlanItUser(AbstractBaseUser, PermissionsMixin):
         verbose_name_plural = 'users'
 
     def get_current_location(self):
-        """ Return the appropriate PlanItLocation for this user."""
+        """Return the appropriate PlanItLocation for this user."""
         return self.primary_organization.location
 
     # All methods below copied from Django's AbstractUser
@@ -134,9 +135,7 @@ class PlanItUser(AbstractBaseUser, PermissionsMixin):
         self.email = self.__class__.objects.normalize_email(self.email)
 
     def get_full_name(self):
-        """
-        Return the first_name plus the last_name, with a space in between.
-        """
+        """Return the first_name plus the last_name, with a space in between."""
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 

--- a/src/django/users/permissions.py
+++ b/src/django/users/permissions.py
@@ -1,4 +1,4 @@
-"""Permission classes and helpers for limiting access to resources/actions"""
+"""Permission classes and helpers for limiting access to resources/actions."""
 
 from rest_framework import permissions
 
@@ -9,8 +9,7 @@ class IsAuthenticatedOrCreate(permissions.BasePermission):
     ALLOWED_ANONYMOUS_ACTIONS = ('create')
 
     def has_permission(self, request, view):
-        """Allow access to anonymous create or authenticated other actions"""
-
+        """Allow access to anonymous create or authenticated other actions."""
         if view.action and view.action in self.ALLOWED_ANONYMOUS_ACTIONS:
             return True
 

--- a/src/django/users/serializers.py
+++ b/src/django/users/serializers.py
@@ -46,7 +46,7 @@ class LocationSerializer(GeoFeatureModelSerializer):
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
-    """Serializer for user organizations"""
+    """Serializer for user organizations."""
 
     location = LocationSerializer()
 
@@ -74,7 +74,8 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    """Serializer for PlanItUser
+    """Serializer for PlanItUser.
+
     Note:
         Retrieves token if available for a user, or returns ``null``
     """


### PR DESCRIPTION
## Overview
Cleans a number of linter errors that appear to have not been caught by Jenkins.

### Notes
- Disables D105, as that was being caught most commonly on the `__str__()` magic function. Use of magic functions is generally discouraged, so this may be something we can manage via PR review.

## Testing Instructions
- No changes are expected
