### PR TITLE
Use organization unit when showing concern data

### DIFF
--- a/src/django/climate_api/utils.py
+++ b/src/django/climate_api/utils.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 
 
+IMPERIAL_TO_METRIC = {'F': 'C', 'in/day': 'mm/day', 'in': 'mm'}
+
+
 def get_api_url(route):
     base_url = settings.CCAPI_HOST
     return "{}/{}".format(base_url, route)

--- a/src/django/planit_data/test_serializers.py
+++ b/src/django/planit_data/test_serializers.py
@@ -29,33 +29,39 @@ class ConcernSerializerTestCase(TestCase):
                                               is_relative=True)
 
     @mock.patch('planit_data.models.Concern.calculate')
-    @mock.patch('planit_data.models.Concern.get_default_units')
-    def test_context_requires_request(self, default_units_mock, calculate_mock):
+    def test_context_requires_request(self, calculate_mock):
         """Ensure the Serializer raises an error if the context does not have a request"""
-        calculate_mock.return_value = 5.3
-        default_units_mock.return_value = 'miles'
+        calculate_mock.return_value = {
+            'value': 5.3,
+            'units': 'miles',
+            'tagline': 'more'
+        }
 
         serializer = ConcernSerializer(self.concern)
         with self.assertRaises(ValueError):
             serializer.data
 
     @mock.patch('planit_data.models.Concern.calculate')
-    @mock.patch('planit_data.models.Concern.get_default_units')
-    def test_context_works_with_request(self, default_units_mock, calculate_mock):
+    def test_context_works_with_request(self, calculate_mock):
         """Ensure the Serializer works if the context does have a request"""
-        calculate_mock.return_value = 5.3
-        default_units_mock.return_value = 'miles'
+        calculate_mock.return_value = {
+            'value': 5.3,
+            'units': 'miles',
+            'tagline': 'more'
+        }
 
         serializer = ConcernSerializer(self.concern, context={'request': self.request})
         # No exception
         serializer.data
 
     @mock.patch('planit_data.models.Concern.calculate')
-    @mock.patch('planit_data.models.Concern.get_default_units')
-    def test_context_request_can_be_set_afterwards(self, default_units_mock, calculate_mock):
+    def test_context_request_can_be_set_afterwards(self, calculate_mock):
         """Ensure the Serializer works when the request is added after construction"""
-        calculate_mock.return_value = 5.3
-        default_units_mock.return_value = 'miles'
+        calculate_mock.return_value = {
+            'value': 5.3,
+            'units': 'miles',
+            'tagline': 'more'
+        }
 
         serializer = ConcernSerializer(self.concern)
         serializer.context['request'] = self.request

--- a/src/django/planit_data/tests/test_views.py
+++ b/src/django/planit_data/tests/test_views.py
@@ -33,11 +33,13 @@ class ConcernViewSetTestCase(APITestCase):
         self.assertEqual(response.data['results'], [])
 
     @mock.patch('planit_data.models.Concern.calculate')
-    @mock.patch('planit_data.models.Concern.get_default_units')
-    def test_concern_list_nonempty(self, default_unit_mock, calculate_mock):
+    def test_concern_list_nonempty(self, calculate_mock):
         indicator = Indicator.objects.create(name='Foobar')
-        calculate_mock.return_value = 5.3
-        default_unit_mock.return_value = 'farthing'
+        calculate_mock.return_value = {
+            'value': 5.3,
+            'units': 'farthing',
+            'tagline': 'more'
+        }
         concern = Concern.objects.create(indicator=indicator,
                                          tagline_positive='more',
                                          tagline_negative='less',
@@ -61,10 +63,12 @@ class ConcernViewSetTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @mock.patch('planit_data.models.Concern.calculate')
-    @mock.patch('planit_data.models.Concern.get_default_units')
-    def test_concern_detail(self, default_units_mock, calculate_mock):
-        calculate_mock.return_value = 5.3
-        default_units_mock.return_value = 'miles'
+    def test_concern_detail(self, calculate_mock):
+        calculate_mock.return_value = {
+            'value': 5.3,
+            'units': 'miles',
+            'tagline': 'more'
+        }
 
         indicator = Indicator.objects.create(name='Foobar')
         concern = Concern.objects.create(indicator=indicator,
@@ -80,7 +84,7 @@ class ConcernViewSetTestCase(APITestCase):
                              {'id': concern.id, 'indicator': 'Foobar',
                               'tagline': 'more', 'isRelative': True, 'value': 5.3,
                               'units': 'miles'})
-        calculate_mock.assert_called_with(self.user.get_current_location().api_city_id)
+        calculate_mock.assert_called_with(self.user.primary_organization)
 
     def test_concern_detail_invalid(self):
         url = reverse('concern-detail', kwargs={'pk': 999})


### PR DESCRIPTION
## Overview

Uses the correct units when calculating and displaying concern data.

### Demo

![screenshot from 2017-12-05 17-16-53](https://user-images.githubusercontent.com/4432106/33633893-57077704-d9e0-11e7-81b8-dfc5d4bf8817.png)

## Testing Instructions

 * Ensure that your user has a primary organization, and that the organization has an associated `PlanItLocation` with a valid `api_city_id`.
 * On the Dashboard the Top Concerns components should show the default weather events for your organization's georegion, but without any concern/indicator data
 * From the Django Admin, [create a `Concern`](http://localhost:8100/admin/planit_data/concern/) and associate with one of your organization's [Weather Events](http://localhost:8100/admin/planit_data/weatherevent/)
 * After refreshing the Dashboard, the Top Concerns component should show the concern value for the weather event you just modified.
 * After changing your organizations units from Imperial to Metric or vice versa, you should see those changes reflected when refreshing the Dashboard.

Closes #179 