### PR TITLE
Add model modal to indicator charts

### DIFF
--- a/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
+++ b/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
@@ -11,9 +11,20 @@
   </div>
   <div [collapse]="isCollapsed">
     <div class="card-block">
-      <div class="chart-toggle">
-        <span>Scenario:</span>
-        <ccc-scenario-toggle [scenario]="scenario" (onScenarioSelected)="scenarioSelected($event)"></ccc-scenario-toggle>
+      <div class="chart-controls">
+        <div class="chart-toggle">
+          <span>Scenario:</span>
+          <ccc-scenario-toggle [scenario]="scenario"
+                               (onScenarioSelected)="scenarioSelected($event)">
+          </ccc-scenario-toggle>
+        </div>
+        <div class="chart-toggle">
+          <span>Models:</span>
+          <ccc-model-modal [dataset]="dataset"
+                           [models]="models"
+                           (onModelsChanged)="modelsChanged($event)">
+          </ccc-model-modal>
+        </div>
       </div>
       <app-chart [indicator]="indicator"
              [city]="city"

--- a/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.ts
+++ b/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import {
-  ChartData,
   Chart,
-  IndicatorRequestOpts,
-  IndicatorQueryParams,
-  Indicator,
+  ChartData,
   City,
   ClimateModel,
   Dataset,
+  Indicator,
+  IndicatorRequestOpts,
+  IndicatorQueryParams,
   Scenario
 } from 'climate-change-components';
 import { Point } from 'geojson';
@@ -27,7 +27,7 @@ export class IndicatorChartComponent implements OnInit {
   public dataset: Dataset;
   public extraParams: IndicatorQueryParams;
   public isCollapsed = false;
-  public models: ClimateModel[];
+  public models: ClimateModel[] = [];
   public scenario = DEFAULT_SCENARIO;
 
   constructor() {}
@@ -45,16 +45,13 @@ export class IndicatorChartComponent implements OnInit {
     this.extraParams = {
       dataset: 'NEX-GDDP'
     };
-    this.models = [{
-      datasets: ['NEX-GDDP'],
-      name: 'BNU-ESM',
-      description: 'BNU-ESM',
-      base_time: null,
-      enabled: true
-    }];
   }
 
   scenarioSelected(scenario: Scenario) {
     this.scenario = scenario;
+  }
+
+  modelsChanged(models: ClimateModel[]) {
+    this.models = models;
   }
 }

--- a/src/angular/planit/src/assets/sass/components/_app-indicator-chart.scss
+++ b/src/angular/planit/src/assets/sass/components/_app-indicator-chart.scss
@@ -2,10 +2,16 @@ app-indicator-chart {
   width: 100%;
 
   .card-block {
-    .chart-toggle {
+    .chart-controls {
       display: flex;
       flex-direction: row;
       align-items: center;
+
+      & > .chart-toggle {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+      }
     }
   }
 }

--- a/src/angular/planit/src/assets/sass/components/indicators/_model-modal.scss
+++ b/src/angular/planit/src/assets/sass/components/indicators/_model-modal.scss
@@ -1,0 +1,29 @@
+.modal-actions {
+  margin-bottom: 20px;
+
+  button {
+    padding: 0;
+    color: #777;
+    border-width: 0;
+    box-shadow: none !important;
+    &:not(:last-child) {
+      border-right: 1px solid #ddd;
+      border-radius: 0;
+      padding-right: 10px;
+      margin-right: 5px;
+    }
+    &:hover {
+      background-color: transparent;
+      opacity: 0.64;
+    }
+  }
+}
+
+.models {
+  column-count: 3;
+  column-gap: 20px;
+
+  label {
+    font-size: $font-size-base;
+  }
+}

--- a/src/angular/planit/src/assets/sass/main.scss
+++ b/src/angular/planit/src/assets/sass/main.scss
@@ -41,6 +41,7 @@
  * Components styling
  * * * */
 @import
+  'components/indicators/model-modal',
   'components/alert',
   'components/button',
   'components/card',

--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -277,7 +277,8 @@ if not CCAPI_HOST:
 CCAPI_REQUEST_TIMEOUT = 30
 # Whitelist for proxy routes to allow. These routes are checked using str.startswith
 CCAPI_ROUTE_WHITELIST = (
+    '^api/climate-data/[0-9]+/.+/indicator/.+/$',
+    '^api/climate-model/$',
     '^api/indicator/$',
     '^api/scenario/$',
-    '^api/climate-data/[0-9]+/.+/indicator/.+/$',
 )


### PR DESCRIPTION
### Demo

![screen shot 2017-12-07 at 11 42 40 am](https://user-images.githubusercontent.com/1818302/33726710-c6a905be-db43-11e7-8bc7-debccc57df80.png)
![screen shot 2017-12-07 at 11 42 35 am](https://user-images.githubusercontent.com/1818302/33726711-c6b27522-db43-11e7-8def-0646357110f4.png)

### Notes

Unstyled (mostly). As in https://github.com/azavea/temperate/pull/269#issuecomment-350013190 this can be styled in a cleanup pass by design.

This modal also does some awkward bouncing. We cannot control the options passed to the model modal to set `animated: false`. I created a new issue to expose modal options in `ccc-model-modal`: azavea/climate-change-components#20

## Testing Instructions

- Ensure modal link exists and works correctly
- Ensure toggling different models in modal updates chart 

Closes #129 
