### PR TITLE
Update is_coastal path to reflect CC API change

### DIFF
--- a/src/django/users/models.py
+++ b/src/django/users/models.py
@@ -22,7 +22,7 @@ class PlanItLocationManager(models.Manager):
             city = make_token_api_request('/api/city/{}/'.format(api_city_id))
             location.name = city['properties']['name']
             location.point = GEOSGeometry(str(city['geometry']))
-            location.is_coastal = city['properties']['is_coastal']
+            location.is_coastal = city['properties']['proximity']['ocean']
             location.save()
         return location
 

--- a/src/django/users/tests/test_models.py
+++ b/src/django/users/tests/test_models.py
@@ -134,7 +134,9 @@ class LocationManagerTestCase(TestCase):
                 ],
                 "name": "Philadelphia",
                 "admin": "PA",
-                "is_coastal": False,
+                "proximity": {
+                    "ocean": False
+                },
                 "population": 1526006,
                 "region": 11
             }
@@ -166,7 +168,9 @@ class LocationManagerTestCase(TestCase):
                 ],
                 "name": "Los Angeles",
                 "admin": "CA",
-                "is_coastal": True,
+                "proximity": {
+                    "ocean": True
+                },
                 "population": 3792621,
                 "region": 18
             }

--- a/src/django/users/tests/test_views.py
+++ b/src/django/users/tests/test_views.py
@@ -150,7 +150,9 @@ class OrganizationApiTestCase(APITestCase):
                 ],
                 "name": "Philadelphia",
                 "admin": "PA",
-                "is_coastal": False,
+                "proximity": {
+                    "ocean": False
+                },
                 "population": 1526006,
                 "region": 11
             }


### PR DESCRIPTION
## Overview
Since is_coastal was never published as the CC API's... API..., in azavea/climate-change-api#788 we change it to a member of a `proximity` collection. This updates Temperate to be prepared to use the new home for the parameter for when the change there goes live on staging and, later, production.

## Testing Instructions
- Tests should still pass
- Once azavea/climate-change-api#788 is merged, organizations should still be able to be created for new locations without KeyError exceptions

Closes #265 