### PR TITLE
Print log message for API requests

### DIFF
--- a/src/django/climate_api/wrapper.py
+++ b/src/django/climate_api/wrapper.py
@@ -1,7 +1,10 @@
+import logging
 import requests
 
 from climate_api.models import APIToken
 from climate_api.utils import get_api_url, serialize_years
+
+logger = logging.getLogger(__name__)
 
 
 def make_token_api_request(route, params=None):
@@ -10,6 +13,7 @@ def make_token_api_request(route, params=None):
     token = APIToken.objects.current()
     headers = {'Authorization': 'Token {}'.format(token)}
 
+    logger.warning("Sending API request to {}".format(url))
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
## Overview
Because we currently have no method of monitoring what and how many API requests are made as a part of synchronous requests to Temperate, this adds a logging statement for each request that we make.

### Notes
See conversation on https://github.com/azavea/temperate/pull/274#discussion_r155862938

## Testing Instructions
- TDB

Closes #284 
