### PR TITLE
Add check to ensure database changes have migrations

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -35,7 +35,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             FLAKE8_ARGS=""
             ANGULAR_LINT_CMD="lint"
 
-            # Make sure we've built a tagged image if 
+            # Make sure we've built a tagged image if
             # not in CI.
             GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                       -f docker-compose.yml \
@@ -70,11 +70,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f docker-compose.test.yml \
                   run --rm angular run test
 
+        echo "Check for missing migrations"
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                  -f docker-compose.yml \
+                  -f docker-compose.test.yml \
+                  run --rm --entrypoint python \
+                  django manage.py makemigrations --check --dry-run
+
         echo "Execute Django tests"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f docker-compose.yml \
                   -f docker-compose.test.yml \
                   run --rm --entrypoint python \
                   django manage.py test --noinput
+
     fi
 fi


### PR DESCRIPTION
## Overview
Adds a step to `scripts/test` to check if any database changes exist that don't have a corresponding migration, like #293

# Demo
```
Check for missing migrations
Starting azaveatemperatepr294suaxvurf6wzkv2sylewcn45dbptvz6ycsjnsnceo3xxclz3xwgwa_database_1 ... 

Starting azaveatemperatepr294suaxvurf6wzkv2sylewcn45dbptvz6ycsjnsnceo3xxclz3xwgwa_database_1 ... done
Migrations for 'users':
  users/migrations/0016_auto_20171211_1804.py
    - Alter field primary_organization on planituser
```

## Testing Instructions
- `scripts/test` should pass
- Make a change to a database model
- `scripts/test` should fail
- Use `scripts/manage makemigrations` to create a migration
- `scripts/test` should pass

Closes #275 
