### PR TITLE
Flag coastal WeatherEvents as coastal_only

### DIFF
--- a/src/django/planit_data/fixtures/weatherevents.json
+++ b/src/django/planit_data/fixtures/weatherevents.json
@@ -49,7 +49,7 @@
         "pk": 7,
         "fields": {
             "name": "Coastal flooding",
-            "coastal_only": false,
+            "coastal_only": true,
             "concern": null
         }
     },
@@ -112,7 +112,7 @@
         "pk": 14,
         "fields": {
             "name": "Ocean acidification",
-            "coastal_only": false,
+            "coastal_only": true,
             "concern": null
         }
     },
@@ -157,7 +157,7 @@
         "pk": 19,
         "fields": {
             "name": "Storm surge",
-            "coastal_only": false,
+            "coastal_only": true,
             "concern": null
         }
     },


### PR DESCRIPTION
## Overview
In #268 we add a number of WeatherEvents to the fixture, some of which were appropriate for #246. This flags the ones specific to coastal areas as `coastal_only`.

### Notes
- Hurricane is left as not coastal only as it can have impact deep inland.

## Testing Instructions
- Import the fixtures
- In the admin panel, examine the Coastal weather events
  - [Coastal flooding](http://localhost:8100/admin/planit_data/weatherevent/7/change/)
  - [Ocean acidification](http://localhost:8100/admin/planit_data/weatherevent/14/change/)
  - [Storm surge](http://localhost:8100/admin/planit_data/weatherevent/19/change/)
  - They should be marked as coastal_only
- Create a new Organization for a non-coastal city like Philadelphia (7 on CC API staging)
- Update that Organization to be [your user's primary organization](http://localhost:8100/admin/users/planituser/)
- Load http://localhost:8100/api/weather-event-rank/
  - You should not see any of the coastal weather events

Closes #246 
