### PR TITLE
Fix #271, small styling changes

### DIFF
--- a/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
+++ b/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
@@ -1,5 +1,4 @@
-<div class="chart"
-     [ngClass]="{'card': true, 'card-full': true, 'collapsed': isCollapsed}">
+<div [ngClass]="{'card': true, 'card-full': true, 'collapsed': isCollapsed}">
   <div class="card-header" role="tab" id="headingOne">
     <a class="add-top-concern">Add as top concern<i class="icon-question-circle-o"></i></a>
     <a (click)="isCollapsed = !isCollapsed">
@@ -11,7 +10,7 @@
   </div>
   <!--We only want to create and show selected indicator chart components to prevent clogging the page with unwanted requests and page updates. Below looks repetitive but [collapse] only provides the accordion UI action which shows/hides the chart guts but doesn't manage requests; *ngIf does that by actually creating/removing DOM components -->
   <div *ngIf="!isCollapsed" [collapse]="isCollapsed">
-    <div class="card-block">
+    <div class="chart card-block">
       <div class="chart-controls">
         <div class="chart-toggle">
           <span>Scenario</span>

--- a/src/angular/planit/src/assets/sass/components/_chart.scss
+++ b/src/angular/planit/src/assets/sass/components/_chart.scss
@@ -2,6 +2,14 @@
   height: 100%;
 }
 
+.chart-controls {
+    min-width: 500px;
+
+    .chart-toggle {
+        flex-wrap: wrap;
+    }
+}
+
 .chart-graphic {
   height: 100%;
   width: 100%;
@@ -12,4 +20,8 @@ ccc-line-graph {
   display: block;
   box-shadow: 2px 2px 10px rgba(0,0,0,.05);
   height: 0;
+}
+
+.card-block {
+  margin: 0 2rem;
 }

--- a/src/angular/planit/src/assets/sass/layout/_content.scss
+++ b/src/angular/planit/src/assets/sass/layout/_content.scss
@@ -111,5 +111,5 @@
 
 .page-intro {
   max-width: 80rem;
-  margin: 4rem 0; 
+  margin: 4rem 0;
 }

--- a/src/angular/planit/src/assets/sass/layout/_frame.scss
+++ b/src/angular/planit/src/assets/sass/layout/_frame.scss
@@ -2,7 +2,7 @@ body:not(#marketing) {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
-  
+
   .main-container {
     display: flex;
     flex: 1;


### PR DESCRIPTION
## Overview

Adding padding to cards caused charts to undesirably redraw wider and wider. The graph svg itself is drawn to the width of `.chart.` I moved `.chart` to somewhere more sensible and this magically fixed #271.

I think it's because the `.chart` card width + line graph padding was wider than the card, thus the graph was drawn wider than it's container, creating a cycle. 

I added flex wrap properties to the toggle bar because it made sense. 

### Demo

![movechartclass](https://user-images.githubusercontent.com/10568752/33943616-9d913e5a-dfe7-11e7-8a65-37515caaa751.gif)

### Notes

#232 is not ultimately handled here

Closes #271 
