### PR TITLE
Use transactions to prevent bad data from spoiling the database

### DIFF
--- a/src/django/users/models.py
+++ b/src/django/users/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import PermissionsMixin
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.mail import send_mail
+from django.db import transaction
 from django.utils import timezone
 
 from django.conf import settings
@@ -16,6 +17,7 @@ from planit_data.models import GeoRegion, WeatherEventRank
 
 class PlanItLocationManager(models.Manager):
 
+    @transaction.atomic
     def from_api_city(self, api_city_id):
         location, created = PlanItLocation.objects.get_or_create(api_city_id=api_city_id)
         if created:

--- a/src/django/users/serializers.py
+++ b/src/django/users/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import authenticate
 from django.contrib.auth.password_validation import validate_password
+from django.db import transaction
 
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
@@ -55,6 +56,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Valid location not provided")
         return location_data
 
+    @transaction.atomic
     def create(self, validated_data):
         location_data = validated_data.pop('location')
         instance = PlanItOrganization.objects.create(**validated_data)


### PR DESCRIPTION
## Overview
In #255, we encounter a problem in that failed attempting to create PlanItOrganization objects will leave incomplete objects in the database, causing future attempts to fail with a cryptic error. This introduces transactions for steps that involve processing after a database change has been made, so the database change can be rolled back if needed.

### Notes
- DEBUG_PROPAGATE_EXCEPTIONS is turned on in the tests to prevent Django from logging the unhandled exceptions we intentionally trigger

## Testing Instructions
- Tests should pass
- Load http://localhost:8100/api/organizations/
- Attempt to create an Organization with an invalid `api_city_id`, like `1234`.
  - It should fail with a 404 error from the Climate Change API
- Refresh
  - No new organization should have been created
- Navigate to an existing Organization with `http://localhost:8100/api/organizations/{id}/`
- Attempt to update it with an invalid `api_city_id` like `1234`
  - It should fail with a 404 error
- Refresh
  - The organization should be unchanged
- Load http://localhost:8100/admin/users/planitlocation/
  - No new PlanItLocations should have been made with a None point

Closes #255
