### PR TITLE
Add adaptive need box and tooltip

### DIFF
--- a/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.html
+++ b/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.html
@@ -1,0 +1,31 @@
+<ng-template #tooltipTemplate>
+<h2>How is adaptive need calculated?</h2>
+<p>
+Here explain what "adaptive need" is and how we are calculating this.
+</p>
+<table class="adaptive-need-table">
+    <tbody>
+        <tr *ngFor="let potentialImpactIndex of [2, 1, 0]"
+            [ngClass]="'pi-' + potentialImpactIndex">
+            <td *ngFor="let adaptiveCapacityIndex of [2, 1, 0]"
+                class="adaptive-capacity-box"
+                [ngClass]="{'selected': potentialImpactIndex == potentialImpact && adaptiveCapacityIndex == adaptiveCapacity,
+                            'ac-0': adaptiveCapacityIndex == 0, 'ac-1': adaptiveCapacityIndex == 1,
+                            'ac-2': adaptiveCapacityIndex == 2}">
+                &nbsp;
+            </td>
+            <th>{{ ['Low', 'Mod', 'High'][potentialImpactIndex] }}</th>
+        </tr>
+        <tr>
+            <th>High</th>
+            <th>Mod</th>
+            <th>Low</th>
+        </tr>
+    </tbody>
+</table>
+</ng-template>
+
+<span [ngClass]="['adaptive-need-box', 'pi-' + potentialImpact, 'ac-' + adaptiveCapacity]"
+      [tooltip]="tooltipTemplate" placement="right"
+       *ngIf="potentialImpact !== undefined && adaptiveCapacity !== undefined">&nbsp;</span>
+<span *ngIf="potentialImpact === undefined || adaptiveCapacity === undefined">--</span>

--- a/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.ts
+++ b/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+
+@Component({
+  selector: 'va-adaptive-need-box',
+  templateUrl: 'adaptive-need-box.component.html'
+})
+export class AdaptiveNeedBoxComponent implements OnInit {
+  @Input() potentialImpact: number;
+  @Input() adaptiveCapacity: number;
+
+  constructor () {}
+
+  ngOnInit() {
+  }
+}

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -30,10 +30,12 @@
         </thead>
         <tbody>
           <tr *ngFor="let risk of risks">
-            <th>{{ risk.adaptiveNeed || '--' }}</th>
+            <th><va-adaptive-need-box
+                    [adaptiveCapacity]="risk.adaptiveCapacity"
+                    [potentialImpact]="risk.potentialImpact"></va-adaptive-need-box></th>
             <th>{{ risk.name }}</th>
-            <th>{{ risk.potentialImpact || '--' }}</th>
-            <th>{{ risk.adaptiveCapacity || '--' }}</th>
+            <th>{{ risk.potentialImpact }}</th>
+            <th>{{ risk.adaptiveCapacity }}</th>
             <th><button class="button">Assess</button></th>
             <th>
                 <div class="btn-group" dropdown>

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.ts
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.ts
@@ -13,10 +13,10 @@ export class AssessmentOverviewComponent implements OnInit {
 
   ngOnInit() {
     this.risks = [
-      {'name': 'Heat on the elderly'},
-      {'name': 'Heat on asphalt'},
-      {'name': 'Extreme cold days on agriculture'},
-      {'name': 'Water-bourne disease on ecological function'},
+      {name: 'Heat on the elderly', potentialImpact: 0, adaptiveCapacity: 2},
+      {name: 'Heat on asphalt', potentialImpact: 1, adaptiveCapacity: 1},
+      {name: 'Extreme cold days on agriculture', potentialImpact: 2, adaptiveCapacity: 0},
+      {name: 'Water-bourne disease on ecological function', potentialImpact: 2, adaptiveCapacity: 2},
     ];
   }
 }

--- a/src/angular/planit/src/app/assessment/assessment.module.ts
+++ b/src/angular/planit/src/app/assessment/assessment.module.ts
@@ -5,11 +5,14 @@ import { AssessmentRoutingModule } from './assessment-routing.module';
 import { SharedModule } from '../shared/shared.module';
 
 import { AssessmentOverviewComponent } from './assessment-overview.component';
+import { AdaptiveNeedBoxComponent } from './adaptive-need-box/adaptive-need-box.component';
+
 import { CreateRiskComponent } from './create-risk.component';
 import { ModalWizardModule } from '../modal-wizard/modal-wizard.module';
 import { RiskWizardComponent, RiskWizardModule } from '../risk-wizard/';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 
 @NgModule({
@@ -19,11 +22,13 @@ import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
     SharedModule,
     RiskWizardModule,
     AssessmentRoutingModule,
-    BsDropdownModule.forRoot()
+    BsDropdownModule.forRoot(),
+    TooltipModule.forRoot()
   ],
   declarations: [
     AssessmentOverviewComponent,
-    CreateRiskComponent
+    CreateRiskComponent,
+    AdaptiveNeedBoxComponent
   ]
 })
 export class AssessmentModule { }

--- a/src/angular/planit/src/app/shared/models/risk.model.ts
+++ b/src/angular/planit/src/app/shared/models/risk.model.ts
@@ -1,9 +1,7 @@
 export class Risk {
-  // TODO: these should be given types once we find out what acceptable values are
-  adaptiveNeed?: any;
   name: string;
-  potentialImpact?: any;
-  adaptiveCapacity?: any;
+  potentialImpact?: number;
+  adaptiveCapacity?: number;
 
   constructor(object: Object) {
     Object.assign(this, object);

--- a/src/angular/planit/src/assets/sass/components/_va-tooltip.scss
+++ b/src/angular/planit/src/assets/sass/components/_va-tooltip.scss
@@ -1,0 +1,45 @@
+$adaptive-need-low: #ffe486;
+$adaptive-need-medium: #fdac7c;
+$adaptive-need-high: #ff565d;
+
+
+.adaptive-need-table {
+    td {
+        width:50px;
+        height:50px;
+    }
+
+    td.selected {
+        border: 1px #000 solid;
+    }
+
+    .pi-1>.ac-2, .pi-0>.ac-1, .pi-0>.ac-2 {
+        background: $adaptive-need-low;
+    }
+
+    .pi-0>.ac-0, .pi-1>.ac-1, .pi-2>.ac-2 {
+        background: $adaptive-need-medium;
+    }
+
+    .pi-2>.ac-1, .pi-2>.ac-0, .pi-1>.ac-0 {
+        background: $adaptive-need-high;
+    }
+}
+
+.adaptive-need-box {
+    width: 50px;
+    height: 50px;
+    display: inline-block;
+
+    &.pi-1.ac-2, &.pi-0.ac-1, &.pi-0.ac-2 {
+        background: $adaptive-need-low;
+    }
+
+    &.pi-0.ac-0, &.pi-1.ac-1, &.pi-2.ac-2 {
+        background: $adaptive-need-medium;
+    }
+
+    &.pi-2.ac-1, &.pi-2.ac-0, &.pi-1.ac-0 {
+        background: $adaptive-need-high;
+    }
+}

--- a/src/angular/planit/src/assets/sass/main.scss
+++ b/src/angular/planit/src/assets/sass/main.scss
@@ -63,7 +63,8 @@
   'components/chart',
   'components/timeslider',
   'components/app-chart',
-  'components/app-indicator-chart';
+  'components/app-indicator-chart',
+  'components/va-tooltip';
 
 /* * * *
  * Page specific styling


### PR DESCRIPTION
## Overview

Add adaptive need box and tooltip. Adjust ng Risk model to represent adaptive capacity and potential impact as a number.

### Demo

![image](https://user-images.githubusercontent.com/539905/33959853-d29edc18-e016-11e7-96dd-aa64d05de655.png)

### Notes

Display of tooltip is pretty broken and needs ~some~ a lot of CSS cleanup. Should this happen as a part of this issue?

## Testing Instructions

 * Visit vulnerability assessment page and mouse-over the adaptive needs

Closes #244 