### PR TITLE
Shift violations.xml output to src directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ npm-debug.log
 # Text editor files
 .vscode
 violations.txt
+violations.xml
 nginx/static

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
                 step([$class: 'WarningsPublisher',
                     parserConfigurations: [[
                         parserName: 'JSLint',
-                        pattern: 'src/angular/planit/violations.xml'
+                        pattern: 'src/angular/planit/src/violations.xml'
                     ], [
                         parserName: 'Pep8',
                         pattern: 'src/django/violations.txt'

--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint --type-check",
-    "lint:ci": "ng lint --type-check --force --format checkstyle > violations.xml",
+    "lint:ci": "ng lint --type-check --force --format checkstyle > src/violations.xml",
     "e2e": "ng e2e",
     "build:prod": "ng build --prod --aot --extract-css --env=prod",
     "postinstall": "npm rebuild node-sass"

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.ts
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.ts
@@ -16,7 +16,9 @@ export class AssessmentOverviewComponent implements OnInit {
       {name: 'Heat on the elderly', potentialImpact: 0, adaptiveCapacity: 2},
       {name: 'Heat on asphalt', potentialImpact: 1, adaptiveCapacity: 1},
       {name: 'Extreme cold days on agriculture', potentialImpact: 2, adaptiveCapacity: 0},
-      {name: 'Water-bourne disease on ecological function', potentialImpact: 2, adaptiveCapacity: 2},
+      {name: 'Water-bourne disease on ecological function', potentialImpact: 2,
+        adaptiveCapacity: 2
+      },
     ];
   }
 }

--- a/src/angular/planit/src/app/modal-wizard/modal-wizard-options.ts
+++ b/src/angular/planit/src/app/modal-wizard/modal-wizard-options.ts
@@ -1,7 +1,7 @@
-import { ModalOptions } from "ngx-bootstrap/modal/modal-options.class";
+import { ModalOptions } from 'ngx-bootstrap/modal/modal-options.class';
 
 export const ModalWizardOptions: ModalOptions = {
   animated: false,
-  backdrop: "static",
-  class: "modal-large"
+  backdrop: 'static',
+  class: 'modal-large'
 };

--- a/src/angular/planit/src/app/modal-wizard/modal-wizard.module.ts
+++ b/src/angular/planit/src/app/modal-wizard/modal-wizard.module.ts
@@ -16,6 +16,6 @@ export class ModalWizardModule {
       providers: [
         { provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: components, multi: true }
       ]
-    }
+    };
   }
 }


### PR DESCRIPTION
## Overview

The root of the working directory inside of the Node.js container is not volume mounted, which prevents writes that occur from within the context of the container instance from propagating out to the virtual machine/NFS file system.

Since the `src` directory is volume mounted, writes within it do propagate outward, allowing Jenkins to read `violations.xml`.

## Testing Instructions

I think that the easiest way to test this is to inspect the Jenkins output from the following jobs:

- http://urbanappsci.internal.azavea.com/job/azavea/job/temperate/job/PR-336/1/console (7f558791725578e175733983e2fe8d2bc7b9ebb0)
- http://urbanappsci.internal.azavea.com/job/azavea/job/temperate/job/PR-336/2/console (32caa4a737a628ef89753cbc971eb0c9de462074)

The first build correctly locates `violations.xml` and reports `jslint` issues in the Jenkins UI. In the second, the linting errors are resolved.

Closes #318 
