### PR TITLE
Move all forRoot calls to AppModule

### DIFF
--- a/src/angular/planit/src/app/app.module.ts
+++ b/src/angular/planit/src/app/app.module.ts
@@ -27,7 +27,12 @@ import { CacheService } from './core/services/cache.service';
 import { UserService } from './core/services/user.service';
 import { WeatherEventService } from './core/services/weather-event.service';
 
-import { ModalModule } from 'ngx-bootstrap';
+import {
+  BsDropdownModule,
+  CollapseModule,
+  TooltipModule,
+  ModalModule
+ } from 'ngx-bootstrap';
 import { AppRoutingModule } from './app-routing.module';
 
 const appRoutes: Routes = [
@@ -48,7 +53,10 @@ const appRoutes: Routes = [
     FormsModule,
     HttpModule,
     // 3rd party
+    BsDropdownModule.forRoot(),
+    CollapseModule.forRoot(),
     ModalModule.forRoot(),
+    TooltipModule.forRoot(),
     // Local
     SharedModule,
     ApiModule.forRoot({

--- a/src/angular/planit/src/app/assessment/assessment.module.ts
+++ b/src/angular/planit/src/app/assessment/assessment.module.ts
@@ -22,8 +22,8 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
     SharedModule,
     RiskWizardModule,
     AssessmentRoutingModule,
-    BsDropdownModule.forRoot(),
-    TooltipModule.forRoot()
+    BsDropdownModule,
+    TooltipModule
   ],
   declarations: [
     AssessmentOverviewComponent,

--- a/src/angular/planit/src/app/indicators/indicators.module.ts
+++ b/src/angular/planit/src/app/indicators/indicators.module.ts
@@ -13,7 +13,7 @@ import { WeatherEventIconPipe } from './weather-event-icon.pipe';
 
 @NgModule({
   imports: [
-    CollapseModule.forRoot(),
+    CollapseModule,
     CommonModule,
     ChartsModule,
     SharedModule,

--- a/src/angular/planit/src/app/shared/shared.module.ts
+++ b/src/angular/planit/src/app/shared/shared.module.ts
@@ -19,7 +19,7 @@ import { NouisliderModule } from 'ng2-nouislider';
   imports: [
     CommonModule,
     RouterModule,
-    BsDropdownModule.forRoot(),
+    BsDropdownModule,
     ChartsModule,
     NouisliderModule
   ],


### PR DESCRIPTION
## Overview

Properly imports third party modules using the `forRoot()` convention.

### Demo

No visible change to the app.

### Notes

Key takeaways [from this blogpost](http://angularfirst.com/the-ngmodule-forroot-convention/) that explains this convention:
- Import the module at the root of the application and register with the forRoot() method
- In other NgModules, use the appropriate non-root form of the import when necessary to import the components and directives
- Importing the additional providers of the forRoot() method theoretically works in child NgModules, but can cause issues with provider scoping and is not recommended

Recommended to read the whole post for the _why_ of the above.

[Angular's official documentation](https://angular.io/guide/ngmodule#configure-core-services-with-coremoduleforroot) on this subject, which lacks quite a bit of context, but would likely make sense after reading the blog post link above.

## Testing Instructions

- All components/pages of the app should continue to work as expected
- Remove `BsDropdownModule` from `assessment.module.ts`. The dropdowns on the VA Overview page `/assessment` should stop working.

Closes #331 
