### PR TITLE
Remove unused sidebar tabs

### DIFF
--- a/src/angular/planit/src/app/shared/sidebar/sidebar.component.ts
+++ b/src/angular/planit/src/app/shared/sidebar/sidebar.component.ts
@@ -7,8 +7,7 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SidebarComponent implements OnInit {
 
-  public tabs = ['Dashboard', 'Indicators', 'Charts', 'Maps', 'Assessment',
-                'Action Steps', 'Resources'];
+  public tabs = ['Dashboard', 'Indicators', 'Assessment', 'Action Steps'];
 
   constructor() { }
 


### PR DESCRIPTION
## Overview

Remove charts, maps, and resources links from sidebar.

Each returned "page not found" for its tab previously.


### Demo

Before:
![temperate_sidebar_before](https://user-images.githubusercontent.com/960264/34055909-32521a24-e19f-11e7-8e14-f6a0747757d1.png)

After:
![temperate_sidebar_after](https://user-images.githubusercontent.com/960264/34055912-35bed710-e19f-11e7-84e6-76e3d53d6faf.png)


### Notes

Went hunting for other related artifacts, but didn't find anything. There is a charts module, which seems to be the one used for the indicator charts page.


## Testing Instructions

 * Should no longer have the removed links in sidebar
 * Nothing should be borken

Closes #279.
