### PR TITLE
Add typeahead to identify step with stubbed data

### DIFF
--- a/src/angular/planit/src/app/app.module.ts
+++ b/src/angular/planit/src/app/app.module.ts
@@ -31,7 +31,8 @@ import {
   BsDropdownModule,
   CollapseModule,
   TooltipModule,
-  ModalModule
+  ModalModule,
+  TypeaheadModule
  } from 'ngx-bootstrap';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -57,6 +58,7 @@ const appRoutes: Routes = [
     CollapseModule.forRoot(),
     ModalModule.forRoot(),
     TooltipModule.forRoot(),
+    TypeaheadModule.forRoot(),
     // Local
     SharedModule,
     ApiModule.forRoot({

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.module.ts
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { FormsModule }   from '@angular/forms';
 
 import { ArchwizardModule } from 'ng2-archwizard';
 
@@ -9,9 +10,13 @@ import { ReviewStepComponent } from './steps/review-step.component';
 import { CapacityStepComponent } from './steps/capacity-step.component';
 import { ImpactStepComponent } from './steps/impact-step.component';
 
+import { TypeaheadModule } from 'ngx-bootstrap';
+
 @NgModule({
     imports: [
-        ArchwizardModule
+        FormsModule,
+        ArchwizardModule,
+        TypeaheadModule
     ],
     exports: [RiskWizardComponent],
     declarations: [

--- a/src/angular/planit/src/app/risk-wizard/steps/identify-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/identify-step.component.html
@@ -1,4 +1,23 @@
 <h3>Identify risk</h3>
 
+<p>
+Match a hazard to a subset of people, structure, or assets (sometimes
+referred to as a &lsquo;community system&rsquo;) that the selected hazard may
+impact.
+</p>
+
+<div>
+    <label for="hazards">Hazards</label>
+    <input class="form-control" name="hazards"
+           [(ngModel)]="hazard"
+           [typeahead]="hazards">
+</div>
+<div>
+    <label for="communitysystem">Community system</label>
+    <input class="form-control" name="communitysystem"
+           [(ngModel)]="communitySystem"
+           [typeahead]="communitySystems">
+</div>
+
 <button type="button" nextStep>Continue</button>
 <button type="button" (click)="cancel()">Cancel</button>

--- a/src/angular/planit/src/app/risk-wizard/steps/identify-step.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/steps/identify-step.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component } from '@angular/core';
+import { AfterViewInit, OnInit, Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { WizardState } from 'ng2-archwizard/dist/navigation/wizard-state.model';
@@ -8,12 +8,23 @@ import { WizardState } from 'ng2-archwizard/dist/navigation/wizard-state.model';
   templateUrl: 'identify-step.component.html'
 })
 
-export class IdentifyStepComponent implements AfterViewInit {
+export class IdentifyStepComponent implements AfterViewInit, OnInit {
 
   public navigationSymbol = '1';
   public title = 'Identify risk';
 
+  public hazards: string[];
+  public hazard: string;
+
+  public communitySystems: string[];
+  public communitySystem: string;
+
   constructor(private router: Router, private wizardState: WizardState) { }
+
+  ngOnInit() {
+    this.hazards = ['one', 'two', 'three'];
+    this.communitySystems = ['four', 'five', 'six'];
+  }
 
   ngAfterViewInit() {
     // Example of how to get current wizard step directive state in step components


### PR DESCRIPTION
## Overview

Add typeahead to the risk wizard identify step.

### Demo

![image](https://user-images.githubusercontent.com/539905/34121430-05e376ea-e3f7-11e7-855b-e0faed4d9e57.png)

### Notes

The typeahead from `ngx-bootstrap` seems fine for our purposes. If there is a better source of pre-filled values for the typeahead, let me know and I can fill them in.

## Testing Instructions

 * Go to vulnerability assessment
 * Click "edit" icon next to header
 * Try using text fields

Closes #218 
