### PR TITLE
Force components version 0.2.2

### DIFF
--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "~4.4.5",
     "bootstrap": "^3.3.7",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "^0.2.2",
+    "climate-change-components": "0.2.2",
     "core-js": "^2.4.1",
     "ng2-archwizard": "^2.1.0",
     "ngx-bootstrap": "^2.0.0-beta.7",

--- a/src/angular/planit/yarn.lock
+++ b/src/angular/planit/yarn.lock
@@ -925,7 +925,7 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
-climate-change-components@^0.2.2:
+climate-change-components@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.2.tgz#e23109e40eac93b67c540eebd26d6b903f0c85ce"
   dependencies:


### PR DESCRIPTION
## Overview

0.2.3 introduces caching which breaks in temperate
due to:

https://github.com/azavea/temperate/issues/287#issuecomment-352053503

Pin components to known working version until fix applied upstream

## Testing Instructions

On current develop, a `docker-compose build angular` followed by `./scripts/server` should cause errors loading the Temperate indicator charts. 

On this branch, a `docker-compose build angular` followed by `./scripts/server` should load Indicator charts as expected, albeit without caching.
