### PR TITLE
Add extra params components to Indicator charts page

### DIFF
--- a/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
+++ b/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.html
@@ -40,6 +40,42 @@
           </ccc-dataset-toggle>
         </div>
       </div>
+      <div class="chart-controls">
+          <ccc-threshold-parameters
+              *ngIf="isThresholdIndicator(indicator.name)"
+              [indicator]="indicator"
+              [extraParams]="extraParams"
+              (thresholdParamSelected)="onExtraParamsSelected($event)">
+          </ccc-threshold-parameters>
+          <ccc-basetemp-parameters
+              *ngIf="isBasetempIndicator(indicator.name)"
+              [indicator]="indicator"
+              [extraParams]="extraParams"
+              (basetempParamSelected)="onExtraParamsSelected($event)">
+          </ccc-basetemp-parameters>
+          <!-- both percentile and historic extra parameters -->
+          <ccc-percentile-historic-parameters
+              *ngIf="isPercentileIndicator(indicator.name) &&
+                     isHistoricIndicator(indicator.name)"
+              [indicator]="indicator"
+              [extraParams]="extraParams"
+              (percentileHistoricParamSelected)="onExtraParamsSelected($event)">
+          </ccc-percentile-historic-parameters>
+          <ccc-percentile-parameters
+              *ngIf="isPercentileIndicator(indicator.name) &&
+                     !isHistoricIndicator(indicator.name)"
+              [indicator]="indicator"
+              [extraParams]="extraParams"
+              (percentileParamSelected)="onExtraParamsSelected($event)">
+          </ccc-percentile-parameters>
+          <ccc-historic-parameters
+              *ngIf="isHistoricIndicator(indicator.name) &&
+                     !isPercentileIndicator(indicator.name)"
+              [indicator]="indicator"
+              [extraParams]="extraParams"
+              (historicParamSelected)="onExtraParamsSelected($event)">
+          </ccc-historic-parameters>
+      </div>
       <app-chart [indicator]="indicator"
              [city]="city"
              [models]="models"

--- a/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.ts
+++ b/src/angular/planit/src/app/indicators/indicator-chart/indicator-chart.component.ts
@@ -10,14 +10,17 @@ import {
   Indicator,
   IndicatorRequestOpts,
   IndicatorQueryParams,
-  Scenario
+  Scenario,
+  isBasetempIndicator,
+  isHistoricIndicator,
+  isPercentileIndicator,
+  isThresholdIndicator
 } from 'climate-change-components';
 
 import {
   DEFAULT_DATASET,
   DEFAULT_SCENARIO
 } from '../indicator-defaults';
-
 
 @Component({
   selector: 'app-indicator-chart',
@@ -31,7 +34,11 @@ export class IndicatorChartComponent implements OnInit {
   @Output() toggled: EventEmitter<boolean> = new EventEmitter();
 
   public dataset: Dataset = DEFAULT_DATASET;
-  public extraParams: IndicatorQueryParams;
+  public extraParams: IndicatorQueryParams = {};
+  public isThresholdIndicator = isThresholdIndicator;
+  public isBasetempIndicator = isBasetempIndicator;
+  public isHistoricIndicator = isHistoricIndicator;
+  public isPercentileIndicator = isPercentileIndicator;
   public models: ClimateModel[] = [];
   public scenario = DEFAULT_SCENARIO;
   public unit: string;
@@ -59,5 +66,9 @@ export class IndicatorChartComponent implements OnInit {
 
   datasetSelected(dataset: Dataset) {
     this.dataset = dataset;
+  }
+
+  onExtraParamsSelected(params: IndicatorQueryParams) {
+    this.extraParams = Object.assign({}, params);
   }
 }

--- a/src/angular/planit/src/app/shared/chart/chart.component.ts
+++ b/src/angular/planit/src/app/shared/chart/chart.component.ts
@@ -19,11 +19,6 @@ import { Chart, ChartData, City, ClimateModel, Dataset, IndicatorRequestOpts,
 
 import { ChartService, IndicatorService } from 'climate-change-components';
 
-import { isBasetempIndicator,
-  isHistoricIndicator,
-  isPercentileIndicator,
-  isThresholdIndicator } from 'climate-change-components';
-
 import * as cloneDeep from 'lodash.clonedeep';
 
 /*
@@ -58,10 +53,6 @@ export class ChartComponent implements OnChanges, OnDestroy, OnInit {
     description: ''
   };
   public dateRange: number[] = [this.firstYear, this.lastYear];
-  public isThresholdIndicator = isThresholdIndicator;
-  public isBasetempIndicator = isBasetempIndicator;
-  public isHistoricIndicator = isHistoricIndicator;
-  public isPercentileIndicator = isPercentileIndicator;
   public noChartMessage = 'Loading...';
 
   public sliderConfig: any = {

--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -280,6 +280,7 @@ CCAPI_ROUTE_WHITELIST = (
     '^api/climate-data/[0-9]+/.+/indicator/.+/$',
     '^api/climate-model/$',
     '^api/dataset/$',
+    '^api/historic-range/$',
     '^api/indicator/$',
     '^api/scenario/$',
 )


### PR DESCRIPTION
Unstyled, can be addressed in #342 or followup pass

### Demo

![screen shot 2017-12-19 at 1 58 27 pm](https://user-images.githubusercontent.com/1818302/34173820-c15ad198-e4c4-11e7-9814-acfb0f74963d.png)
![screen shot 2017-12-19 at 1 58 13 pm](https://user-images.githubusercontent.com/1818302/34173821-c162aa9e-e4c4-11e7-9321-53321241ee87.png)

### Notes

All charts that use extra params should now work as expected, just like the Lab.

@alexelash I left the components unstyled, since they'll need to be merged with your PR #342 anyways. Happy to pair to ensure we catch all of the potential variations exposed here.

## Testing Instructions

Test at least the following Indicators to test one from each bucket:
- max_temperature_threshold
- cooling_degree_days
- heat_wave_duration_index
- extreme_precipitation_events

Closes #317
