### PR TITLE
Add views to list, update, create and delete organization risks

### DIFF
--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -27,6 +27,7 @@ from users.views import CurrentUserView, PlanitObtainAuthToken, OrganizationView
 router = routers.DefaultRouter()
 router.register(r'organizations', OrganizationViewSet)
 router.register(r'users', UserViewSet)
+router.register(r'risks', planit_data_views.OrganizationRiskView, base_name='organizationrisk')
 
 urlpatterns = [
     url(r'^api/climate-api/(?P<route>.*)$',

--- a/src/django/planit_data/tests/test_serializers.py
+++ b/src/django/planit_data/tests/test_serializers.py
@@ -3,8 +3,8 @@ from unittest import mock
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
-from planit_data.models import Concern, Indicator
-from planit_data.serializers import ConcernSerializer
+from planit_data.models import CommunitySystem, Concern, Indicator, WeatherEvent
+from planit_data.serializers import ConcernSerializer, OrganizationRiskSerializer
 from users.models import PlanItLocation, PlanItOrganization, PlanItUser
 
 
@@ -68,3 +68,38 @@ class ConcernSerializerTestCase(TestCase):
 
         # No exception
         serializer.data
+
+
+class OrganizationRiskSerializerTestCase(TestCase):
+    def setUp(self):
+        self.user = PlanItUser.objects.create_user('mike@mike.phl', 'Mike', 'M',
+                                                   password='mike12345')
+        location = PlanItLocation.objects.create(api_city_id=14)
+        org = PlanItOrganization.objects.create(name='Test', location=location)
+        self.user.organizations.add(org)
+        self.user.primary_organization = org
+        self.user.save()
+
+        self.request_factory = APIRequestFactory()
+        self.request = self.request_factory.get('/blah/')
+        self.request.user = self.user
+
+        self.weather_event = WeatherEvent.objects.create(name='Really hot days')
+        self.community_system = CommunitySystem.objects.create(name='Old folks')
+
+    def test_create_context_requires_request(self):
+        """Ensure the Serializer raises an error if the context does not have a request"""
+        serializer = OrganizationRiskSerializer(data={'weatherEvent': self.weather_event.id,
+                                                      'communitySystem': self.community_system.id})
+        serializer.is_valid()
+        with self.assertRaises(ValueError):
+            serializer.save()
+
+    def test_create_context_works_with_request(self):
+        """Ensure the Serializer works if the context does have a request"""
+        serializer = OrganizationRiskSerializer(data={'weatherEvent': self.weather_event.id,
+                                                      'communitySystem': self.community_system.id},
+                                                context={'request': self.request})
+        serializer.is_valid()
+        # No exception
+        serializer.save()

--- a/src/django/planit_data/views.py
+++ b/src/django/planit_data/views.py
@@ -2,16 +2,31 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.viewsets import ReadOnlyModelViewSet, ModelViewSet
 
-from planit_data.models import Concern, WeatherEventRank
-from planit_data.serializers import ConcernSerializer, WeatherEventRankSerializer
+from planit_data.models import Concern, OrganizationRisk, WeatherEventRank
+from planit_data.serializers import (
+    ConcernSerializer,
+    OrganizationRiskSerializer,
+    WeatherEventRankSerializer,
+)
 
 
 class ConcernViewSet(ReadOnlyModelViewSet):
     queryset = Concern.objects.all().order_by('id')
     serializer_class = ConcernSerializer
     permission_classes = [IsAuthenticated]
+
+
+class OrganizationRiskView(ModelViewSet):
+    model_class = OrganizationRisk
+    permission_classes = [IsAuthenticated]
+    serializer_class = OrganizationRiskSerializer
+    pagination_class = None
+
+    def get_queryset(self):
+        org_id = self.request.user.primary_organization_id
+        return OrganizationRisk.objects.filter(organization_id=org_id)
 
 
 class WeatherEventRankView(APIView):


### PR DESCRIPTION
## Overview

Add views to list, update, create and delete organization risks, needed to power the vulnerability assessment page

### Demo

![localhost_8100_api_risks_ 1](https://user-images.githubusercontent.com/4432106/34187507-b4171ab0-e4ff-11e7-905d-d90fde8902ac.png)


### Notes

Editing `relatedAdaptiveValues` with the DRF HTML form is a bit wonky, but functions correctly in Raw data mode, which is the more important thing (see https://github.com/encode/django-rest-framework/issues/5601)


## Testing Instructions

 * http://localhost:8100/api/risks/

Closes #214
