### PR TITLE
Use wizard strict mode for navigation

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.html
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.html
@@ -1,5 +1,5 @@
 <wizard #wizard
-        navigationMode="free"
+        navigationMode="strict"
         navBarLocation="left"
         navBarLayout="large-empty-symbols">
   <app-action-assess-step class="wizard-step"

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
@@ -1,5 +1,5 @@
 <wizard #wizard
-        navigationMode="free"
+        navigationMode="strict"
         navBarLocation="left"
         navBarLayout="large-empty-symbols">
   <app-risk-step-identify class="wizard-step"


### PR DESCRIPTION
## Overview

Do not allow user to progress through wizards without completing non-optional steps, by using wizard library [strict navigation mode](https://github.com/madoar/ng2-archwizard#navigationmode).


### Notes

"Semi-strict" mode will still let the user progress past a non-completed, required step by clicking the sidebar text. "Strict" mode (used here) requires the user to click "continue" to move forward; the sidebar text is only clickable for back navigation. Note that all but the first and last steps of the risk wizard are optional.


## Testing Instructions

 * http://localhost:4210/assessment/risk/wizard
 * Should not be able to visit any other wizard steps until first step completed
 * Should be able to visit previous steps via clicking on wizard sidebar text
 * Should only be able to progress forward to the next step

Closes #377.
