### PR TITLE
Disable escape key modal close

### DIFF
--- a/src/angular/planit/src/app/modal-wizard/modal-wizard-options.ts
+++ b/src/angular/planit/src/app/modal-wizard/modal-wizard-options.ts
@@ -3,5 +3,6 @@ import { ModalOptions } from 'ngx-bootstrap/modal/modal-options.class';
 export const ModalWizardOptions: ModalOptions = {
   animated: false,
   backdrop: 'static',
-  class: 'modal-large'
+  class: 'modal-large',
+  keyboard: false
 };


### PR DESCRIPTION
## Overview

Page behind modal lacks content, so disable clicking escape key in modal to go to empty page.

Set ngx-modal option to [disable escape key from modal](https://valor-software.com/ngx-bootstrap/#/modals#service-nested).


### Notes

The wizard modals in this project do not display over actual page content, but display within their own component that has the same frame as the parent page, but lacks the content; that is why simply closing the wizard results in a blank page.


## Testing Instructions

 * http://localhost:4210/actions/action/wizard
 * http://localhost:4210/assessment/risk/wizard
 * Escape key should do nothing in either wizard
 * Wizard exit modes should all direct back to the original page

Closes #371.
