### PR TITLE
Scaffold basic working action step cards

### DIFF
--- a/src/angular/planit/src/app/action-steps/action-card/action-card.component.html
+++ b/src/angular/planit/src/app/action-steps/action-card/action-card.component.html
@@ -1,0 +1,7 @@
+<div class="action-card">
+  <div class="action-card-content">
+    <h3>{{ risk.weatherEvent.name }} on {{ risk.communitySystem.name }}</h3>
+    <button class="take-action btn"
+            routerLink="action/wizard">Take action</button>
+  </div>
+</div>

--- a/src/angular/planit/src/app/action-steps/action-card/action-card.component.ts
+++ b/src/angular/planit/src/app/action-steps/action-card/action-card.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+import { Risk } from '../../shared';
+
+@Component({
+  selector: 'as-action-card',
+  templateUrl: './action-card.component.html'
+})
+export class ActionCardComponent implements OnInit {
+
+  @Input() risk: Risk;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/angular/planit/src/app/action-steps/action-steps-overview.component.html
+++ b/src/angular/planit/src/app/action-steps/action-steps-overview.component.html
@@ -6,11 +6,20 @@
       <h1 class="heading">Adaptation Actions</h1>
       <button class="button icon-edit" routerLink="action/wizard"></button>
     </section>
-    <section>
-      <div class="actions-empty">
+    <section *ngIf="risks">
+      <div *ngIf="!risks.length" class="actions-empty">
         <h2>You'll need to assess risks before you can take action.</h2>
         <p>Once you have risks assessed in your Vulnerability Assessment, you can plan to mitigate their impact here.</p>
         <a class="button" routerLink="/assessment">Assess Risks</a>
+      </div>
+      <div *ngIf="risks.length" class="actions-available">
+        <h2>Risks acted upon</h2>
+        <!-- TODO: Progress bar here -->
+        <h2>In Progress</h2>
+        <div class="action-card-container">
+          <as-action-card *ngFor="let risk of risks"
+                          [risk]="risk"></as-action-card>
+        </div>
       </div>
     </section>
   </main>

--- a/src/angular/planit/src/app/action-steps/action-steps-overview.component.ts
+++ b/src/angular/planit/src/app/action-steps/action-steps-overview.component.ts
@@ -1,12 +1,21 @@
 import { Component, OnInit } from '@angular/core';
 
+import { RiskService } from '../core/services/risk.service';
+import { Risk } from '../shared';
+
 @Component({
   selector: 'as-overview',
   templateUrl: 'action-steps-overview.component.html'
 })
 
 export class ActionStepsOverviewComponent implements OnInit {
-  constructor() { }
 
-  ngOnInit() { }
+  public risks: Risk[];
+
+  constructor(private riskService: RiskService) { }
+
+  ngOnInit() {
+    this.riskService.list().subscribe(risks => this.risks = risks);
+  }
+
 }

--- a/src/angular/planit/src/app/action-steps/action-steps.module.ts
+++ b/src/angular/planit/src/app/action-steps/action-steps.module.ts
@@ -8,6 +8,7 @@ import { ActionStepsRoutingModule } from './action-steps-routing.module';
 import { CreateActionComponent } from './create-action.component';
 import { ModalWizardModule } from '../modal-wizard/modal-wizard.module';
 import { SharedModule } from '../shared/shared.module';
+import { ActionCardComponent } from './action-card/action-card.component';
 
 @NgModule({
   imports: [
@@ -20,7 +21,8 @@ import { SharedModule } from '../shared/shared.module';
   exports: [],
   declarations: [
     ActionStepsOverviewComponent,
-    CreateActionComponent
+    CreateActionComponent,
+    ActionCardComponent
   ],
   providers: [],
 })

--- a/src/angular/planit/src/assets/sass/components/_action-steps.scss
+++ b/src/angular/planit/src/assets/sass/components/_action-steps.scss
@@ -1,0 +1,25 @@
+.action-card-container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.action-card {
+  height: 200px;
+  width: 310px;
+  margin: 5px;
+  background-color: $gray-1;
+  border: #bdc0ea 1px solid;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.action-card-content {
+  margin-top: 20%;
+}
+
+.take-action {
+  background-color: #48e166;
+  color: white;
+}

--- a/src/angular/planit/src/assets/sass/main.scss
+++ b/src/angular/planit/src/assets/sass/main.scss
@@ -46,6 +46,7 @@
   'components/shared/option-dropdown',
   'components/shared/sidebar',
   'components/alert',
+  'components/action-steps',
   'components/archwizard',
   'components/app-wizard',
   'components/button',


### PR DESCRIPTION
## Overview

Scaffolds out the action cards in their empty state. 

### Demo

<img width="657" alt="screen shot 2018-01-05 at 11 25 42 am" src="https://user-images.githubusercontent.com/10568752/34618174-e3f1d220-f20b-11e7-8488-77fa5a6d5cb1.png">


![action-card](https://user-images.githubusercontent.com/10568752/34624524-a5be74a0-f223-11e7-8867-03c0e1ed2c0c.gif)

### Notes

Loading the `/actions` page, you should smoothly render either the empty state or the active state with cards state, with no flashing.
To get empty state, you'll have to delete the risks via the admin panel. 

I did some basic flex box. It's not perfect, but the DSM did get me this far ^0^

Closes #306, #307 

  
  