### PR TITLE
Bump to components 0.2.8

### DIFF
--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "~4.4.5",
     "bootstrap": "^3.3.7",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "0.2.5",
+    "climate-change-components": "0.2.8",
     "core-js": "^2.4.1",
     "ng2-archwizard": "^2.1.0",
     "ngx-bootstrap": "^2.0.0-rc.0",

--- a/src/angular/planit/yarn.lock
+++ b/src/angular/planit/yarn.lock
@@ -925,9 +925,9 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
-climate-change-components@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.5.tgz#ba084174506be6d56aa39a4e2e00c6d0b0cdc500"
+climate-change-components@0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.8.tgz#831701bdb6c5306a164f2e8dc5a9e7d0798104e6"
   dependencies:
     "@angular/animations" "^4.3.6"
     "@angular/common" "^4.3.6"
@@ -995,9 +995,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codelyzer@~3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-3.2.2.tgz#abbd4e5956c435677740846e5858c915f89679c3"
+codelyzer@~4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-4.0.2.tgz#d5e2390b97d95e73a7b1e6f0cf03e16cbf35b06f"
   dependencies:
     app-root-path "^2.0.1"
     css-selector-tokenizer "^0.7.0"


### PR DESCRIPTION
## Overview

Bumps components library, which incorporates fixes for #349 

### Demo

Should no longer see error present in #349 when viewing indicator charts

## Notes

Components 0.2.6 and 0.2.7 are buggy releases due to our testing process for the library being subpar. We'll need to address the testing difficulties if we choose to do any more work on this library. Issues noted in the components CHANGELOG with notes to prefer 0.2.8

## Testing Instructions

`./scripts/update && ./scripts/server`, then view an indicator chart on the indicator page, tweaking a bunch of different model params

Closes #349 

  