### PR TITLE
Init empty Action model in ActionWizardComponent

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
@@ -31,7 +31,11 @@ export class ActionWizardComponent implements AfterViewInit, OnDestroy, OnInit {
 
   constructor(private session: WizardSessionService<Action>) { }
 
-  ngOnInit() {}
+  ngOnInit() {
+    // TODO (#393): Save/populate Action via the API
+    const action = new Action({});
+    this.session.setData(action);
+  }
 
   ngOnDestroy() {}
 


### PR DESCRIPTION
## Overview

Minor change that resolves errors about the client side action model being uninitialized when attempting to call the WizardStepComponent.save() method in the steps. This should provide the scaffolding necessary to defer additional changes to the save logic such that work should be able on each step's individual form model.

### Notes

Change broken out from the same one in my in progress Step 2 branch, where saving of the step model to the session works as expected:

https://github.com/azavea/temperate/blob/feature/awf/as-wizard-step-two%23314/src/angular/planit/src/app/action-wizard/action-wizard.component.ts#L34-L37

Remaining work can be deferred until #393 

## Testing Instructions

N/A. Could pull down `feature/awf/as-wizard-step-two#314` and verify that saving of the step succeeds if so desired.

Connects #393 
