### PR TITLE
Change description fields in risk wizard to use <textarea>

### DIFF
--- a/src/angular/planit/src/app/risk-wizard/steps/capacity-step/capacity-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/capacity-step/capacity-step.component.html
@@ -16,7 +16,7 @@
     </div>
     <div class="step-form-control">
       <h5>Description</h5>
-      <input type="text" formControlName="adaptiveCapacityDescription">
+      <textarea formControlName="adaptiveCapacityDescription"></textarea>
     </div>
   </form>
 </div>

--- a/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
@@ -13,7 +13,7 @@
     </div>
     <div class="step-form-control">
       <h5>Impact Description</h5>
-      <input type="text" formControlName="impactDescription" required>
+      <textarea formControlName="impactDescription" required></textarea>
     </div>
   </form>
 </div>

--- a/src/angular/planit/src/app/risk-wizard/steps/review-step/review-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/review-step/review-step.component.html
@@ -18,17 +18,13 @@
 <div>
     Potential Impact: {{ impactOptions.get(risk.impactMagnitude)?.label }}
     <button class="button icon-edit" goToStep="2"></button>
-    <div *ngIf="risk.impactDescription">
-        {{ risk.impactDescription }}
-    </div>
+    <div *ngIf="risk.impactDescription" class="review-description">{{ risk.impactDescription }}</div>
 </div>
 
 <div>
     Adaptive Capacity: {{ chanceOptions.get(risk.adaptiveCapacity)?.label }}
     <button class="button icon-edit" goToStep="3"></button>
-    <div *ngIf="risk.adaptiveCapacityDescription">
-        {{ risk.adaptiveCapacityDescription }}
-    </div>
+    <div *ngIf="risk.adaptiveCapacityDescription" class="review-description">{{ risk.adaptiveCapacityDescription }}</div>
     <div class="freeform-multiselect" *ngIf="risk.relatedAdaptiveValues?.length > 0">
         <div class="selected-option" *ngFor="let relatedAdaptiveValue of risk.relatedAdaptiveValues">
             {{ relatedAdaptiveValue }}

--- a/src/angular/planit/src/assets/sass/pages/_vulnerability-assessment.scss
+++ b/src/angular/planit/src/assets/sass/pages/_vulnerability-assessment.scss
@@ -10,3 +10,8 @@
     }
   }
 }
+app-risk-step-review {
+  .review-description {
+    white-space: pre-wrap;
+  }
+}


### PR DESCRIPTION
## Overview
Changes risk wizard description to use `<textarea>` to allow users to enter multi-line descriptions.

Also updates styling on the review step to preserve line breaks.

### Demo

![screenshot from 2018-01-12 11-27-53](https://user-images.githubusercontent.com/4432106/34884732-a58a223c-f78b-11e7-86b1-d099db89ebb5.png)
![screenshot from 2018-01-12 11-27-38](https://user-images.githubusercontent.com/4432106/34884736-a912b7c0-f78b-11e7-94d2-6d265097fcd6.png)


## Testing Instructions

 * `./scripts/server`

Closes #417
