### PR TITLE
Update the adaptive need popover to reflect latest wireframes

### DIFF
--- a/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.html
+++ b/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.html
@@ -7,31 +7,29 @@
       </p>
     </div>
     <div class="adaptive-need-table col-6">
+      <span class="chart-left">Potential Impact</span>
       <table cellpadding="2">
         <thead>
           <tr>
-            <th colspan="3">Adaptive Capacity</th>
+            <th colspan="5">Adaptive Capacity</th>
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let potentialImpactIndex of [2, 1, 0]"
-            [ngClass]="'pi-' + potentialImpactIndex">
-            <td *ngFor="let adaptiveCapacityIndex of [2, 1, 0]"
-              class="adaptive-capacity-box"
+          <tr *ngFor="let potentialImpactIndex of [4, 3, 2, 1, 0]">
+            <td *ngFor="let adaptiveCapacityIndex of [4, 3, 2, 1, 0]"
+                class="adaptive-capacity-box ac-{{ adaptiveCapacityIndex }} pi-{{ potentialImpactIndex }}"
               [ngClass]="{'selected': potentialImpactIndex == potentialImpactBin
-                && adaptiveCapacityIndex == adaptiveCapacityBin,
-                'ac-0': adaptiveCapacityIndex == 0,
-                'ac-1': adaptiveCapacityIndex == 1,
-                'ac-2': adaptiveCapacityIndex == 2}">
+                && adaptiveCapacityIndex == adaptiveCapacityBin}">
               &nbsp;
             </td>
-            <th>{{ ['Low', 'Mod', 'High'][potentialImpactIndex] }}</th>
+            <td *ngIf="potentialImpactIndex == 4">High</td>
+            <td *ngIf="potentialImpactIndex == 3" rowspan="3" class="arrow-down"><div></div></td>
+            <td *ngIf="potentialImpactIndex == 0">Low</td>
           </tr>
-          <span class="chart-left">Potential Impact</span>
           <tr>
-            <th>High</th>
-            <th>Mod</th>
-            <th>Low</th>
+            <td>High</td>
+            <td colspan="3" class="arrow-over"><div></div></td>
+            <td>Low</td>
           </tr>
         </tbody>
       </table>

--- a/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.ts
+++ b/src/angular/planit/src/app/assessment/adaptive-need-box/adaptive-need-box.component.ts
@@ -22,19 +22,18 @@ export class AdaptiveNeedBoxComponent implements OnInit {
     this.adaptiveCapacityBin = this.binRelativeOption(this.adaptiveCapacity);
   }
 
-  // takes a risk enum value and returns an integer between 0 and 2, or undefined if 'Unsure'
+  // takes a risk enum value and returns an integer between 0 and 4, or undefined if 'Unsure'
   private binRelativeOption(val: OrgRiskRelativeOption): number {
     if (val === OrgRiskRelativeOption.Low) {
-      // low
       return 0;
-    } else if (val === OrgRiskRelativeOption.Moderate ||
-               val === OrgRiskRelativeOption.ModeratelyLow ||
-               val === OrgRiskRelativeOption.ModeratelyHigh) {
-      // medium
+    } else if (val === OrgRiskRelativeOption.ModeratelyLow) {
       return 1;
-    } else if (val === OrgRiskRelativeOption.High) {
-      // high
+    } else if (val === OrgRiskRelativeOption.Moderate) {
       return 2;
+    } else if (val === OrgRiskRelativeOption.ModeratelyHigh) {
+      return 3;
+    } else if (val === OrgRiskRelativeOption.High) {
+      return 4;
     } else {
       // unsure
       return undefined;

--- a/src/angular/planit/src/assets/sass/components/_va-popover.scss
+++ b/src/angular/planit/src/assets/sass/components/_va-popover.scss
@@ -1,6 +1,8 @@
-$adaptive-need-low: #ffe486;
-$adaptive-need-medium: #fdac7c;
-$adaptive-need-high: #ff565d;
+$adaptive-need-high: #fa0c16;
+$adaptive-need-mod-high: #f75824;
+$adaptive-need-mod: #fa8530;
+$adaptive-need-mod-low: #f7a526;
+$adaptive-need-low: #f8cb2b;
 
 .va-popover {
   display: flex;
@@ -18,34 +20,82 @@ $adaptive-need-high: #ff565d;
     margin-left: 2rem;
 
     table {
-      border-spacing: 3px;
-      border-collapse: separate;
+      border-spacing: 0px;
+      border-collapse: collapse;
     }
 
     td {
-      border: white;
-      width: 50px;
-      height: 50px;
+      width: 33px;
+      height: 33px;
+
+      &:last-child {
+        padding-left: 3px;
+      }
     }
 
     th {
-    text-align: center;
+      text-align: center;
     }
 
     td.selected {
       border: 1px #000 solid;
     }
 
-    .pi-1>.ac-2, .pi-0>.ac-1, .pi-0>.ac-2 {
-      background: $adaptive-need-low;
+    .arrow-over, .arrow-down {
+      position: relative;
+
+      > div {
+        border: 0.5px solid #999;
+        margin: auto;
+
+        &:before, &:after {
+          content: '';
+          height: 0;
+          border: 0.5px solid #999;
+          width: 10px;
+          position: absolute;
+        }
+      }
     }
 
-    .pi-0>.ac-0, .pi-1>.ac-1, .pi-2>.ac-2 {
-      background: $adaptive-need-medium;
+    .arrow-over {
+      padding-left: 5px;
+
+      > div {
+        height: 0;
+        width: 100%;
+
+        &:before, &:after {
+          right: -1px;
+        }
+        &:before {
+          transform: rotate(45deg);
+          bottom: 19px;
+        }
+        &:after {
+          transform: rotate(135deg);
+          bottom: 13px;
+        }
+      }
     }
 
-    .pi-2>.ac-1, .pi-2>.ac-0, .pi-1>.ac-0 {
-      background: $adaptive-need-high;
+    .arrow-down {
+      > div {
+        height: 100%;
+        width: 0;
+
+        &:before, &:after {
+          bottom: 4px;
+        }
+        &:before {
+          transform: rotate(135deg);
+          right: 8px;
+        }
+        &:after {
+          transform: rotate(225deg);
+          right: 15px;
+        }
+      }
     }
   }
 
@@ -56,6 +106,7 @@ $adaptive-need-high: #ff565d;
     position: absolute;
     padding-left: 3rem;
     font-weight: bold;
+    bottom: 43px;
   }
 
   .row {
@@ -77,16 +128,26 @@ $adaptive-need-high: #ff565d;
   width: 50px;
   height: 50px;
   display: inline-block;
+}
 
-  &.pi-1.ac-2, &.pi-0.ac-1, &.pi-0.ac-2 {
+.adaptive-need-box, .adaptive-need-table td {
+  &.pi-1.ac-4, &.pi-0.ac-3, &.pi-0.ac-4 {
     background: $adaptive-need-low;
   }
 
-  &.pi-0.ac-0, &.pi-1.ac-1, &.pi-2.ac-2 {
-    background: $adaptive-need-medium;
+  &.pi-3.ac-4, &.pi-2.ac-4, &.pi-2.ac-3, &.pi-1.ac-3, &.pi-1.ac-2, &.pi-0.ac-2, &.pi-0.ac-1 {
+    background: $adaptive-need-mod-low;
   }
 
-  &.pi-2.ac-1, &.pi-2.ac-0, &.pi-1.ac-0 {
+  &.pi-4.ac-4, &.pi-3.ac-3, &.pi-2.ac-2, &.pi-1.ac-1, &.pi-0.ac-0 {
+    background: $adaptive-need-mod;
+  }
+
+  &.pi-4.ac-3, &.pi-4.ac-2, &.pi-3.ac-2, &.pi-3.ac-1, &.pi-2.ac-1, &.pi-2.ac-0, &.pi-1.ac-0 {
+    background: $adaptive-need-mod-high;
+  }
+
+  &.pi-4.ac-1, &.pi-3.ac-0, &.pi-4.ac-0 {
     background: $adaptive-need-high;
   }
 }


### PR DESCRIPTION
## Overview

 - Switches from a 3x3 to a 5x5 grid, which matches the 5 possible values of the underlying data fields
 - Switches some `<th>` elements to a more appropriate `<td>` element
 - Adds in CSS arrows from High -> Low on the bottom & right side of the grid

### Demo

![screenshot from 2018-01-12 15-30-54](https://user-images.githubusercontent.com/4432106/34894219-7cf122f8-f7ae-11e7-91a1-01dbbfe8721d.png)


### Notes

This differs _slightly_ from the screenshot attached to #433 as after discussing with @alexelash she didn't want borders between the grid cells.


## Testing Instructions

 * `./scripts/server`
 * Add or edit a risk so it has any value other than "Unsure" for both Potential Impact and Adaptive Capacity.

Closes #433
