### PR TITLE
Disallow empty text to be added as option

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
@@ -32,7 +32,11 @@ export class FreeformMultiselectComponent implements ControlValueAccessor, OnCha
   }
 
   public add() {
-    this.selectedOptions.add(this.selected);
+    const selected = this.selected.trim();
+    if (!selected) {
+      return;
+    }
+    this.selectedOptions.add(selected);
     this.availableOptions.delete(this.selected);
     this.onChange(Array.from(this.selectedOptions));
     this.selected = '';


### PR DESCRIPTION
### Demo

**Entering only whitespace:**

Before click:
<img width="997" alt="screen shot 2018-01-12 at 3 52 37 pm" src="https://user-images.githubusercontent.com/1818302/34894839-f772953c-f7b0-11e7-8f25-889a5b4aad41.png">

After click:
<img width="993" alt="screen shot 2018-01-12 at 3 52 43 pm" src="https://user-images.githubusercontent.com/1818302/34894843-f98bcba4-f7b0-11e7-8382-320d4f66d597.png">

**Entering text with untrimmed whitespace:**

Before click:
<img width="1000" alt="screen shot 2018-01-12 at 3 52 55 pm" src="https://user-images.githubusercontent.com/1818302/34894873-1be5611a-f7b1-11e7-9fad-71ee3efea0c6.png">

After click:
<img width="989" alt="screen shot 2018-01-12 at 3 53 00 pm" src="https://user-images.githubusercontent.com/1818302/34894877-22d9850a-f7b1-11e7-97a8-d42d66b9c7ec.png">

### Notes

Unfortunately this one was not addressed as part of #430 :(

## Testing Instructions

- Ensure that blank text cannot be added to the set of adaptive values on Step 4 of the Risk Wizard
- Ensure any leading/trailing whitespace is trimmed from any entered freeform text

Closes #436 
