### PR TITLE
Display related indicators section when relevant

### DIFF
--- a/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.html
+++ b/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.html
@@ -1,10 +1,12 @@
 <ng-template #riskPopoverTemplate>
   <p>Donec dictum hendrerit dui, nec dictum ante molestie eleifend. Quisque accumsan nisl lectus, in vulputate erat iaculis quis. Aenean at nisl vehicula, fermentum leo vel, ultricies sapien.
   </p>
-  <h4>Related Indicators</h4>
-  <p *ngFor="let indicator of indicators">
-    <a (click)="openIndicatorModal(indicator)">{{ indicator.label }}</a>
-  </p>
+  <div *ngIf="indicators?.length">
+    <h4>Related Indicators</h4>
+    <p *ngFor="let indicator of indicators">
+      <a (click)="openIndicatorModal(indicator)">{{ indicator.label }}</a>
+    </p>
+  </div>
 </ng-template>
 
 <div class="va-risk" #popover="bs-popover" [popover]="riskPopoverTemplate"


### PR DESCRIPTION
## Overview

Some clean up to the popover on Risk. Show the `Related Indicators` section only when there's indicators.

### Demo

<img width="776" alt="screen shot 2018-01-15 at 11 58 50 am" src="https://user-images.githubusercontent.com/10568752/34953693-9d0ec380-f9eb-11e7-9617-0544ac321f54.png">


<img width="432" alt="screen shot 2018-01-15 at 11 58 55 am" src="https://user-images.githubusercontent.com/10568752/34953694-9d17f202-f9eb-11e7-8b5f-545b34f41c1e.png">

## Notes

Since `indicators` is initialized as `[]`, we shouldn't run into the issue of calling `.length` on null but I did a check for `indicators` anyway

## Testing Instructions

Checkout different popovers and ensure the section shows only when there's indicators 

Closes #435 
