### PR TITLE
Bump climate-change-components to 0.2.10

### DIFF
--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "~4.4.5",
     "bootstrap": "^3.3.7",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "0.2.8",
+    "climate-change-components": "0.2.10",
     "core-js": "^2.4.1",
     "ng2-archwizard": "^2.1.0",
     "ngx-bootstrap": "^2.0.0-rc.0",


### PR DESCRIPTION
## Overview

New version includes "Guard against undefined this.climateModels"

## Testing Instructions

 * Run `scripts/update`
 * See that when climate models modal is opened, an error is not thrown

Closes https://github.com/azavea/climate-change-components/issues/33
