### PR TITLE
Swap <th> with <td> for data rows

### DIFF
--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -37,22 +37,22 @@
         </thead>
         <tbody>
           <tr *ngFor="let risk of risks">
-            <th><va-adaptive-need-box
+            <td><va-adaptive-need-box
               [adaptiveCapacity]="risk.adaptiveCapacity"
-              [potentialImpact]="risk.impactMagnitude"></va-adaptive-need-box></th>
-            <th>
+              [potentialImpact]="risk.impactMagnitude"></va-adaptive-need-box></td>
+            <td>
               <va-risk-popover [risk]="risk"></va-risk-popover>
-            </th>
-            <th>{{ risk.impactMagnitude }}</th>
-            <th>{{ risk.adaptiveCapacity }}</th>
-            <th>
+            </td>
+            <td>{{ risk.impactMagnitude }}</td>
+            <td>{{ risk.adaptiveCapacity }}</td>
+            <td>
               <button class="button va-status-button"
                       *ngIf="!(risk.impactMagnitude || risk.adaptiveCapacity)"
                       [routerLink]="['risk', risk.id]">Assess</button>
               <button *ngIf="risk.impactMagnitude || risk.adaptiveCapacity"
                 class="button va-status-button in-progress">Take Action</button>
-            </th>
-            <th>
+            </td>
+            <td>
               <div class="btn-group" dropdown>
                 <button dropdownToggle type="button" class="btn button dropdown-toggle">
                   <span class="icon-ellipsis"></span>
@@ -69,7 +69,7 @@
                   </li>
                 </ul>
               </div>
-            </th>
+            </td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Overview
Causes styling to change, due to no longer falling back on browser defaults. Browser defaults can vary from browser to browser, so relying on them to produce a specific design can be dangerous. This also seems to fit the wireframes, which don't have the row items in bold.

### Demo
<img width="917" alt="screen shot 2018-01-17 at 8 49 37 am" src="https://user-images.githubusercontent.com/1032849/35046301-8bea90aa-fb64-11e7-9b52-29778fdc6acc.png">

## Testing Instructions
- Open the Assessment panel
- Inspect one of the data rows
  - Data should be enclosed in `<td>` elements, not `<th>`

Closes #407
