### PR TITLE
Modify Content Security Policy to allow inlined images

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
 	map $http_x_forwarded_proto $policy {
 		default "";
-		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval';";
+		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data:;";
 	}
 
 	include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
## Overview

Fix CSP violations for data URL images when site served over https.

Nginx configuration defines a restrictive Content Security Policy; modify it to allow images served as a data URL.


### Demo

![image](https://user-images.githubusercontent.com/960264/35115665-fa332c1e-fc56-11e7-97a9-422de96ed1e7.png)


### Notes

See notes on #373.

Images under 10kb are inlined as data URLs as part of the webpack build configuration, which cannot be overridden while continuing to use the Angular CLI to build and serve the project. See this issue on the CLI: angular/angular-cli#8945.

Project defines a restrictive [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) header in the nginx configuration that would result in errors when data URL image sources used, when site served over https. This relaxes that restriction.

## Testing Instructions

 - Start an ngrok server on the nginx port: `ngrok http 8000`
 - Add the ngrok host to the `ALLOWED_HOSTS` in the Django settings
 - Start the server with `--nginx` flag
 - Visit the https (*not* the http) ngrok site in the browser
 - The lightning image (used for flooding, hurricane, etc.) should display under 'Top Concerns'
 - The CSP header set on the page should contain the new rule for `img-src`


Fixes #373.
