### PR TITLE
Install django registration from pinned commit

### DIFF
--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -3,6 +3,11 @@ FROM quay.io/azavea/django:1.11-python3.6-slim
 RUN mkdir -p /usr/src
 WORKDIR /usr/src
 
+# Install git to install requirement from pinned commit
+RUN set -ex \
+    && apt-get update -yq \
+    && apt-get install -y git
+
 COPY requirements.txt /usr/src/
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -5,7 +5,7 @@ djangorestframework-gis==0.12.0
 django-amazon-ses==0.3.0
 django-debug-toolbar==1.8
 django-extensions==1.9.1
-django-registration==2.3
+git+git://github.com/ubernostrum/django-registration.git@d6ab58d8fd20709b4c7dd335ea67c6c961bb9368
 django-watchman>=0.12,<0.12.99
 factory-boy==2.9.2
 flake8==3.4.1


### PR DESCRIPTION
## Overview

Pin version to commit that fixes #327.
Also install git, to install from commit.

See #330; this adds `git` package.

## Testing Instructions

 * `./scripts/update` should build Django container with pinned commit
 * Account registration workflow should still work


Closes #327 
