### PR TITLE
Fix opening the new risk wizard

### DIFF
--- a/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.ts
@@ -101,7 +101,11 @@ export class HazardStepComponent extends RiskWizardStepComponent<HazardStepFormM
   updateRiskIndicators() {
     this.indicatorService.list().subscribe(indicators => {
       this.indicators = indicators.filter(indicator => {
-        return this.risk.weather_event.indicators.includes(indicator.name);
+        if (this.risk.weather_event.indicators) {
+          return this.risk.weather_event.indicators.includes(indicator.name);
+        } else {
+          return false;
+        }
       });
     });
   }


### PR DESCRIPTION
## Overview

We were trying to load the related indicators when opening the Risk wizard, but when creating a new risk indicators is undefined and was causing an error

### Notes

Using `scripts/server` will show an error in the console but allow you to continue anyway, using `scripts/server --nginx` should replicate the bug this is fixing.


## Testing Instructions

 * `scripts/update`
 * `scripts/server --nginx`

Closes https://github.com/azavea/temperate/issues/494