### PR TITLE
Remove plus icon from indicator on indicator list

### DIFF
--- a/src/angular/planit/src/app/indicators/indicators.component.html
+++ b/src/angular/planit/src/app/indicators/indicators.component.html
@@ -35,9 +35,6 @@
             [indicator]="indicator"
             [city]="city"
             (toggled)="indicatorToggled(indicator.name, $event)">
-          <div header-action>
-            <button class="button button-link card-title-button" title="Add to top concerns"><i class="icon-plus-squared"></i><i class="icon-ok-squared hidden"></i></button>
-          </div>
         </app-collapsible-chart>
       </div>
     </section>


### PR DESCRIPTION
## Overview

The icon hinted to the user that an indicator could be added to a list, but that is not the case. It is removed here to reduce confusion.

### Demo

Before
![image](https://user-images.githubusercontent.com/1042475/35450412-ef4b8b42-028d-11e8-8953-998e1d248bc6.png)

After
![image](https://user-images.githubusercontent.com/1042475/35450388-dd89b078-028d-11e8-8223-97501e8de00a.png)

### Notes

The copy at the top of the page states:

> These are the indicators that we think you should be including in your risk assessment. Feel free to add and remove from below – you know your city best.

Should this copy also be updated?

## Testing Instructions

- Visit http://localhost:4210/indicators
- Verify that the plus icons have been removed from the items in the indicators list.

Closes #486
