### PR TITLE
Link to action wizard for risks on assessment page

### DIFF
--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -48,8 +48,9 @@
               <button class="button va-status-button"
                       *ngIf="!risk.isAssessed()"
                       [routerLink]="['risk', risk.id]">Assess</button>
-              <button *ngIf="!!risk.isAssessed()"
-                class="button va-status-button in-progress">Take Action</button>
+              <button class="button va-status-button in-progress"
+                      *ngIf="!!risk.isAssessed()"
+                      [routerLink]="['/actions/action/wizard', risk.id]">Take Action</button>
             </td>
             <td>
               <div class="btn-group" dropdown>


### PR DESCRIPTION
## Overview

Opens the action wizard with the risk information prepopulated.

Also, the take action button attributes were reorganized to match the
button above it in the DOM.

### Demo

![climate](https://user-images.githubusercontent.com/1042475/35518746-65a5f076-04e0-11e8-876b-97a85b81dc14.gif)

## Testing Instructions

- From the Dashboard, navigate to the vulnerability assessment page.
- Click the take action button for one of the risks.
- Verify that the action wizard is opened and that the risk description is used in the risk field on the first page of the wizard.

Closes #506