### PR TITLE
Require user input before showing suggestions

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
@@ -3,7 +3,7 @@
          [(ngModel)]="selected"
          (typeaheadOnSelect)="add()"
          [typeahead]="availableOptions"
-         [typeaheadMinLength]="0"
+         [typeaheadMinLength]="1"
          [typeaheadScrollable]="true"
          [typeaheadOptionsInScrollableView]="5"
          [typeaheadOptionsLimit]="100"


### PR DESCRIPTION
## Overview

In order to prevent adding a value from the multi-select by just pressing the tab key, require the user to enter at least one character into the input before showing any suggestions. This prevents the suggestion list from appearing when the field gets focus.

### Demo

![jan-29-2018 14-20-29](https://user-images.githubusercontent.com/1042475/35529632-9b456f94-04ff-11e8-8fd3-794159038fa5.gif)

### Notes

This is consistent with the behavior on the typeahead demo page: https://valor-software.com/ngx-bootstrap/#/typeahead

## Testing Instructions

- Navigate to the Adaptive Capacity page of the risk wizard.
- Tab your way through the form fields, and ensure that the "Related Adaptive Values" suggestion menu does not appear.
- Go back to the field, and start typing a phrase. Verify the menu opens after the first character is pressed.

Closes #481