### PR TITLE
Link to homepage for login for new, activated user

### DIFF
--- a/src/django/planit/context_processors.py
+++ b/src/django/planit/context_processors.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+
+def app_settings(request):
+    return {
+        'CCAPP_HOME': settings.CCAPP_HOME
+    }

--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -155,6 +155,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'planit.context_processors.app_settings',
             ],
         },
     },
@@ -273,6 +274,8 @@ LOGGING = {
 }
 
 # APPLICATION SETTINGS
+
+CCAPP_HOME = 'http://localhost:4210' if ENVIRONMENT == 'Development' else '/'
 
 # Climate API Configuration
 CCAPI_EMAIL = os.getenv('CCAPI_EMAIL')

--- a/src/django/users/templates/base.html
+++ b/src/django/users/templates/base.html
@@ -22,7 +22,8 @@
         </div>
         <div class="navbar-right">
           <nav>
-            {% if user.is_authenticated %}
+            {% if 'complete' not in request.path %}
+              {% if user.is_authenticated %}
                 <a href="{% url 'planit_home' %}">Home</a>
                 <button class="btn btn-default dropdown-toggle" type="button"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="true"
@@ -37,8 +38,9 @@
                 <ul class="dropdown-menu" aria-labelledby="accountDropdown">
                     <li><a href="{% url 'auth_logout' %}">Log out</a></li>
                 </ul>
-            {% else %}
+              {% else %}
                 <a href="{% url 'auth_login' %}">{% trans "Log in" %}</a>
+              {% endif %}
             {% endif %}
           </nav>
         </div>

--- a/src/django/users/templates/registration/activation_complete.html
+++ b/src/django/users/templates/registration/activation_complete.html
@@ -8,6 +8,6 @@
 <body>
     {% block content %}
     <p>{% trans "Your account is now activated." %}</p>
-    <a href="{% url 'auth_login' %}" class="btn btn-primary">{% trans 'Login' %}</a>
+    <a href="{{ CCAPP_HOME }}" class="btn btn-primary">{% trans 'Login' %}</a>
     {% endblock %}
 </body>


### PR DESCRIPTION
## Overview

Update the login link on the user activation page to point to the app homepage instead of the `django-registration` provided login page. That login page is not integrated into the app.

Also, remove the login header link from the registration completion page because this links to the `django-registration` provided login page.

### Demo

![jan-30-2018 11-31-30](https://user-images.githubusercontent.com/1042475/35578123-2dcbf926-05b1-11e8-80f7-a5af8a54145a.gif)

### Notes

- The approach taken here is somewhat minimal and only addresses the primary environments. Running `./scripts/server --nginx` and running the app outside of the container are not covered by this PR. Addressing those environments seemed like overkill for this particular fix.
- I think a more robust solution would involve verifying the user, than redirecting them to the homepage automatically, opening up the login modal and displaying a message that their account is activated. These seems outside the scope of this card, but I can create follow-up cards if this is desired.
- I was unable to mimic staging or production locally (by setting the Django environment), but I will follow-up and test this on staging once it's deployed.

## Testing Instructions

- Visit the homepage and create a new user.
- Go to the verification page via the link posted into the Django logs
- Click the "Login" page and verify you are directed to the homepage.

Closes #210