### PR TITLE
Require user input before showing suggestions

### DIFF
--- a/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.html
@@ -22,7 +22,7 @@
                                     typeaheadOptionField="name"
                                     (blur)="itemBlurred('risk')"
                                     [typeahead]="namedRisks"
-                                    [typeaheadMinLength]="0"
+                                    [typeaheadMinLength]="1"
                                     [typeaheadScrollable]="true"
                                     [typeaheadOptionsInScrollableView]="5"
                                     [container]="'body'"

--- a/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.html
@@ -10,7 +10,7 @@
              type="text"
              formControlName="action_type"
              [typeahead]="actionTypes"
-             [typeaheadMinLength]="0">
+             [typeaheadMinLength]="1">
     </div>
     <div class="step-form-control">
       <label for="step-implementation-action-goal">Action goal</label>

--- a/src/angular/planit/src/app/risk-wizard/steps/identify-step/identify-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/identify-step/identify-step.component.html
@@ -12,7 +12,7 @@
                                   (typeaheadOnSelect)="itemSelected('weather_event', $event)"
                                   (blur)="itemBlurred('weather_event')"
                                   [typeahead]="weatherEvents"
-                                  [typeaheadMinLength]="0"
+                                  [typeaheadMinLength]="1"
                                   [typeaheadScrollable]="true"
                                   [typeaheadOptionsInScrollableView]="5"
                                   [container]="'body'">
@@ -30,7 +30,7 @@
                                   (typeaheadOnSelect)="itemSelected('community_system', $event)"
                                   (blur)="itemBlurred('community_system')"
                                   [typeahead]="communitySystems"
-                                  [typeaheadMinLength]="0"
+                                  [typeaheadMinLength]="1"
                                   [typeaheadScrollable]="true"
                                   [typeaheadOptionsInScrollableView]="5"
                                   [container]="'body'">


### PR DESCRIPTION
## Overview

These inputs should have been addressed in #521, but they do not use the shared multi-select component. They use the typeahead component directly. The same approach is used here as in #521.

### Notes

Discovered while testing #521 on staging.

## Testing Instructions

- Tab your way through the form fields, and ensure that the suggestion menu does not appear.
- Go back to the field, and start typing a phrase. Verify the menu opens after the first character is pressed.

- The following inputs are addressed by this:
  - Both fields on the first page of the risk wizard
  - Second field on the first page of the action wizard
  - First field on the second page of the action wizard

Closes #481 