### PR TITLE
Add loading spinner for top concerns

### DIFF
--- a/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.html
+++ b/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.html
@@ -1,4 +1,7 @@
-<div class="card-content top-concerns">
+<div class="loading-wrapper" *ngIf="weatherEvents === undefined">
+  <div class="loading loading-spinner loading-large loading-primary"></div>
+</div>
+<div class="card-content top-concerns" *ngIf="weatherEvents !== undefined">
   <div *ngFor="let weatherEvent of weatherEvents" class="concern {{ weatherEvent.display_class }}">
     <div class="concern-content">
       <div class="concern-options">


### PR DESCRIPTION
## Overview
Adds a loading spinner to show the component is loading data (Versus has successfully loaded nothing).

### Demo
<img width="1143" alt="screen shot 2018-02-02 at 4 50 27 pm" src="https://user-images.githubusercontent.com/1032849/35756425-468c5df4-0839-11e8-8982-565b1c81bf68.png">

## Testing Instructions
- Open the Indicators page
  - You should see a loading spinner for the Top Concerns section

Closes #496