### PR TITLE
Lowercase WeatherEvents and CommunitySystems in sentences

### DIFF
--- a/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.html
+++ b/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.html
@@ -13,7 +13,7 @@
   container="body"
   outsideClick="true"
   popoverTitle="{{ risk.weather_event.name }} on {{ risk.community_system.name }}"
-  placement="right">{{ risk.weather_event.name }} on {{ risk.community_system.name }}
+  placement="right">{{ risk.weather_event.name }} on {{ risk.community_system.name | lowercase }}
 </div>
 
 <app-modal-template #indicatorModal

--- a/src/angular/planit/src/app/risk-wizard/steps/capacity-step/capacity-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/capacity-step/capacity-step.component.html
@@ -1,6 +1,6 @@
 <div class="step-header">
   <h3>Adaptive Capacity</h3>
-  Determine how capable you think your city is at mitigating the future impact of <strong>{{ risk.weather_event?.name }} on {{ risk.community_system?.name }}</strong> here.
+  Determine how capable you think your city is at mitigating the future impact of <strong>{{ risk.weather_event?.name | lowercase }} on {{ risk.community_system?.name | lowercase }}</strong> here.
 </div>
 <div class="step-content">
   <form [formGroup]="form">

--- a/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.html
@@ -7,7 +7,7 @@
 <div class="step-header">
   <h3>Hazard</h3>
   <div *ngIf="risk.weather_event?.name">
-    How will <em>{{ risk.weather_event.name }}</em> change over time?
+    How will <em>{{ risk.weather_event.name | lowercase }}</em> change over time?
   </div>
 </div>
 <div class="step-content">
@@ -49,7 +49,7 @@
 
 
 <app-modal-template #indicatorChartModal
-    title="Viewing indicators related to {{ risk.weather_event.name }}">
+    title="Viewing indicators related to {{ risk.weather_event.name | lowercase }}">
 
   <app-force-collapse-chart-container
       [indicators]="indicators"

--- a/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
@@ -1,7 +1,7 @@
 <div class="step-header">
   <h3>Impact</h3>
   <!--TODO (issue #366): Calculate # years from plan's goal date -->
-  How will this hazard affect <strong>{{ risk.community_system?.name }}</strong> over the next five years?
+  How will this hazard affect <strong>{{ risk.community_system?.name | lowercase }}</strong> over the next five years?
 </div>
 <div class="step-content">
   <form [formGroup]="form">

--- a/src/angular/planit/src/app/risk-wizard/steps/review-step/review-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/review-step/review-step.component.html
@@ -1,4 +1,4 @@
-<h3>{{ risk.weather_event.name }} impact on {{ risk.community_system.name }}</h3>
+<h3>{{ risk.weather_event.name }} impact on {{ risk.community_system.name | lowercase }}</h3>
 
 <div>
     Probability: {{ chanceOptions.get(risk.probability)?.label }}


### PR DESCRIPTION
## Overview

Lowercases `WeatherEvent`s and `CommunitySystem`s within sentences so that the text reads naturally.

### Demo

![image](https://user-images.githubusercontent.com/539905/35823959-46ed9c02-0a7f-11e8-85dd-ed48c95aa565.png)

## Testing Instructions

 * Click around
 * Make sure `WeatherEvent`s and `CommunitySystems` are not capitalized in the middle of a sentence

Closes #468 