### PR TITLE
Use new scenario toggle buttons

### DIFF
--- a/src/angular/planit/package.json
+++ b/src/angular/planit/package.json
@@ -25,7 +25,7 @@
     "@angular/router": "~4.4.5",
     "bootstrap": "^3.3.7",
     "bootstrap-sass": "^3.3.7",
-    "climate-change-components": "0.2.11",
+    "climate-change-components": "0.2.12",
     "core-js": "^2.4.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",

--- a/src/angular/planit/yarn.lock
+++ b/src/angular/planit/yarn.lock
@@ -940,9 +940,9 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
-climate-change-components@0.2.11:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.11.tgz#26ff3d1faa1c109e316a771205627430d9fd9514"
+climate-change-components@0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/climate-change-components/-/climate-change-components-0.2.12.tgz#cb1dad1661c34c54b5bbddcfd8c3b09b86c0877a"
   dependencies:
     "@types/geojson" "^1.0.3"
     d3 "^4.10.0"


### PR DESCRIPTION
## Overview

Updates the chart scenario toggle buttons to use the scenario alias instead of the technical scenario name.

Relies on https://github.com/azavea/climate-change-components/pull/38 and https://github.com/azavea/climate-change-api/pull/797.

### Demo

![feb-06-2018 13-36-57](https://user-images.githubusercontent.com/1042475/35877279-e3b560b0-0b42-11e8-8ef6-5a27f348d218.gif)

### Notes

3586268 is a temporary commit to aid in testing. It will be swapped for a commit that updates the https://github.com/azavea/climate-change-components version once https://github.com/azavea/climate-change-components/pull/38 is merged.

## Testing Instructions

- Provision a local version of https://github.com/azavea/climate-change-api
- Checkout this branch: https://github.com/azavea/climate-change-api/pull/797.
- Apply the following change to the settings file, subbing your computer name in.

```diff
diff --git a/django/climate_change_api/climate_change_api/settings.py b/django/climate_change_api/climate_change_api/settings.py
index 113e4dd..b8e125a 100644
--- a/django/climate_change_api/climate_change_api/settings.py
+++ b/django/climate_change_api/climate_change_api/settings.py
@@ -39,7 +39,7 @@ if not DEBUG and SECRET_KEY.startswith('SECRET_KEY'):
 if DEBUG:
     docker_helper.wait_for_database()

-ALLOWED_HOSTS = os.getenv('CC_ALLOWED_HOSTS', '').split(',')
+ALLOWED_HOSTS = os.getenv('CC_ALLOWED_HOSTS', 'computer-name.internal.azavea.com').split(',')

 if '' in ALLOWED_HOSTS:
     ALLOWED_HOSTS.remove('')
@@ -337,9 +337,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated'
     ],
-    'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication'],
+    'DEFAULT_AUTHENTICATION_CLASSES': [],
     'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
     'PAGE_SIZE': 20,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
```
- Run the API.
- Checkout the branch for this PR.
- Download this version of the `climate-change-components`, which was generated from https://github.com/azavea/climate-change-components/pull/38 and place it in the following directory: `src/angular/planit/`. [climate-change-components-0.2.12.tgz.zip](https://github.com/azavea/temperate/files/1700445/climate-change-components-0.2.12.tgz.zip). **Make sure to unzip the `tgz` file**
- Run `./scripts/update` to install the new version of the components library.
- Update `src/django/docker-compose.env` to point to the local API you have running. An example:

```
...
CCAPI_HOST=http://pigeon.internal.azavea.com:8088

# Replace your CC API credentials below
CCAPI_EMAIL=ccesari@azavea.com  # Make sure to use local credentials
CCAPI_PASSWORD=*****
```
- Run the app.
- Visit the indicators page and open some of the charts.
- Verify the scenario toggle buttons labels are updated, and that they a tooltip with the RCP name.

Closes #295 