### PR TITLE
Use category name for tooltip

### DIFF
--- a/src/angular/planit/src/app/action-steps/action-card/action-card.component.html
+++ b/src/angular/planit/src/app/action-steps/action-card/action-card.component.html
@@ -24,7 +24,7 @@
       <h5>Categories</h5>
       <i *ngFor="let category of action.categories"
          class="{{ category.icon }}"
-         tooltip="{{ category.description }}"
+         tooltip="{{ category.name }}"
          placement="bottom"></i>
     </div>
   </div>


### PR DESCRIPTION
## Overview
Since category description will be a more verbose description of what the category represents, for tooltips describing the icon we want to use the shorter name to provide some context without overwhelming the user.

### Demo
<img width="339" alt="screen shot 2018-02-07 at 3 16 42 pm" src="https://user-images.githubusercontent.com/1032849/35939428-1b9b3b08-0c1a-11e8-9be2-9a445dd483a8.png">

## Testing Instructions
- Create or edit an action so that it has associated categories
- In the Adaptation Actions page, mouse over one of the category icons
  - You should see a tooltip providing a short name for the category icon

Closes #505 
