### PR TITLE
Show line breaks for text values on action wizard review step

### DIFF
--- a/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.html
@@ -10,7 +10,7 @@
         Action
         <button class="button icon-edit" goToStep="0"></button>
       </h4>
-      <p>{{ action.name || '--' }}</p>
+      <p class="review-description">{{ action.name || '--' }}</p>
     </div>
     <div class="review-item">
       <h4>
@@ -43,7 +43,7 @@
         Implementation details
         <button class="button icon-edit" goToStep="1"></button>
       </h4>
-      <p>{{ action.implementation_details || '--' }}</p>
+      <p class="review-description">{{ action.implementation_details || '--' }}</p>
     </div>
     <div class="review-item">
       <h4>
@@ -61,7 +61,7 @@
         Effect on adaptive capacity
         <button class="button icon-edit" goToStep="2"></button>
       </h4>
-      <p>{{ action.improvements_adaptive_capacity || '--' }}</p>
+      <p class="review-description">{{ action.improvements_adaptive_capacity || '--' }}</p>
     </div>
     <div class="review-item"
          [ngClass]="{warning: !action.improvements_impacts }">
@@ -69,7 +69,7 @@
         Reduction in potential impact
         <button class="button icon-edit" goToStep="2"></button>
       </h4>
-      <p>{{ action.improvements_impacts || '--' }}</p>
+      <p class="review-description">{{ action.improvements_impacts || '--' }}</p>
     </div>
     <div class="review-item"
          [ngClass]="{warning: !action.collaborators }">
@@ -111,7 +111,7 @@
         Funding
         <button class="button icon-edit" goToStep="4"></button>
       </h4>
-      <p>{{ action.funding || '--' }}</p>
+      <p class="review-description">{{ action.funding || '--' }}</p>
     </div>
   </div>
 

--- a/src/angular/planit/src/assets/sass/pages/_action-steps.scss
+++ b/src/angular/planit/src/assets/sass/pages/_action-steps.scss
@@ -27,4 +27,7 @@ app-action-review-step {
       }
     }
   }
+  .review-description {
+    white-space: pre-wrap;
+  }
 }


### PR DESCRIPTION


## Overview

Show line breaks for text values on action wizard review step

### Demo

![screenshot from 2018-02-07 17-17-50](https://user-images.githubusercontent.com/4432106/35944659-38779a1c-0c2b-11e8-9e10-66d410fbdf43.png)
![screenshot from 2018-02-07 17-18-05](https://user-images.githubusercontent.com/4432106/35944664-3b891f78-0c2b-11e8-8e95-8f38c019e02e.png)



## Testing Instructions

 * Enter text with multiple line breaks for any of the `<textarea>` fields in the action wizard
 * Line breaks should be preserved when those values are shown on the review step

Fixes #509
