### PR TITLE
Add Climate API city detail to proxy whitelist

### DIFF
--- a/src/angular/planit/src/app/core/services/city.service.ts
+++ b/src/angular/planit/src/app/core/services/city.service.ts
@@ -25,7 +25,7 @@ export class CityService {
     return Observable.create((observer) => {
       this.userService.current().subscribe(user => {
         const api_city_id = user.primary_organization.location.properties.api_city_id;
-        const url = `${environment.apiUrl}/api/climate-api/api/city/${api_city_id}`;
+        const url = `${environment.apiUrl}/api/climate-api/api/city/${api_city_id}/`;
         this.apiHttp.get(url).subscribe(resp => {
           const json = resp.json();
           if (json) {

--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -295,6 +295,7 @@ CCAPI_ROUTE_WHITELIST = (
     '^api/indicator/$',
     '^api/scenario/$',
     '^api/city/$',
+    '^api/city/[0-9]+/$',
 )
 
 # Vulnerability Assessment Configuration


### PR DESCRIPTION
## Testing Instructions

 - `./scripts/server` and you should no longer see console/network errors retrieving the city detail view from the API.

Closes #599 
