### PR TITLE
Feature/jf/risk wizard header

### DIFF
--- a/src/angular/planit/src/app/assessment/edit-risk/edit-risk.component.html
+++ b/src/angular/planit/src/app/assessment/edit-risk/edit-risk.component.html
@@ -1,5 +1,1 @@
-<a class="button button-link" routerLink="/assessment">
-  <span class="icon icon-left-open"></span> Back
-</a>
-
 <app-risk-wizard [risk]="risk"></app-risk-wizard>

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
@@ -1,3 +1,12 @@
+<div class="container wizard-header"
+      *ngIf="identifyStep.weather_event?.name && identifyStep.community_system?.name">
+  <p class="row">Assess the effect of</p>
+  <div class="row">
+    <h2>
+      {{ identifyStep.weather_event.name }} on {{ identifyStep.community_system.name }}
+    </h2>
+  </div>
+</div>
 <wizard #wizard
         navigationMode="free"
         navBarLocation="left"

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewChecked,
+         ChangeDetectorRef,
+         Component,
+         Input,
+         OnInit,
+         ViewChild } from '@angular/core';
 
 // Import from root doesn't seem to pickup types, so import directly from file
 import { WizardComponent } from 'ng2-archwizard/dist/components/wizard.component';
@@ -17,7 +22,7 @@ import { ReviewStepComponent } from './steps/review-step/review-step.component';
   templateUrl: 'risk-wizard.component.html',
   providers: [WizardSessionService]
 })
-export class RiskWizardComponent implements OnInit {
+export class RiskWizardComponent implements OnInit, AfterViewChecked {
   // this.wizard.navigation and this.wizard.model are not available until after AfterViewInit
 
   @ViewChild(WizardComponent) public wizard: WizardComponent;
@@ -29,7 +34,12 @@ export class RiskWizardComponent implements OnInit {
 
   @Input() risk: Risk;
 
-  constructor(private session: WizardSessionService<Risk>) {}
+  constructor(private session: WizardSessionService<Risk>,
+              private changeDetector: ChangeDetectorRef) {}
+
+  ngAfterViewChecked() {
+    this.changeDetector.detectChanges();
+  }
 
   ngOnInit() {
     if (!this.risk) {


### PR DESCRIPTION
## Overview

Add the header to the risk wizard, similar to the action wizard #580 

### Demo

![risk-wiz-header](https://user-images.githubusercontent.com/10568752/36002251-78878d7a-0cf7-11e8-980f-1408a10d4a0c.gif)


### Notes

See commit message for info about the AfterViewInit change.
I didn't do any styling.

## Testing Instructions

Check that the risk header shows up/doesn't as appropriate without errors for new and edited risks.

Closes #535 
