### PR TITLE
Allow navigation to any step in the action wizard

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.html
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.html
@@ -12,16 +12,21 @@
   </div>
 </div>
 <wizard #wizard
-        navigationMode="strict"
+        class="custom-steps"
+        navigationMode="free"
         navBarLocation="left"
         navBarLayout="large-empty-symbols">
 
   <app-action-assess-step class="wizard-step"
                           #assessStep
                           wizardStep
+                          optionalStep
                           [canExit]="assessStep.save"
-                          stepTitle="{{ assessStep.title }}"
                           navigationSymbol="{{ assessStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': assessStep.isStepComplete()}">1</span>
+      {{ assessStep.title }}
+    </ng-template>
   </app-action-assess-step>
 
   <app-action-implementation-step class="wizard-step"
@@ -31,6 +36,10 @@
                           [canExit]="implementationStep.save"
                           stepTitle="{{ implementationStep.title }}"
                           navigationSymbol="{{ implementationStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': implementationStep.isStepComplete()}">2</span>
+      {{ implementationStep.title }}
+    </ng-template>
   </app-action-implementation-step>
 
   <app-action-improvements-step class="wizard-step"
@@ -40,6 +49,10 @@
                           [canExit]="improvementsStep.save"
                           stepTitle="{{ improvementsStep.title }}"
                           navigationSymbol="{{ improvementsStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': improvementsStep.isStepComplete()}">3</span>
+      {{ improvementsStep.title }}
+    </ng-template>
   </app-action-improvements-step>
 
   <app-action-category-step class="wizard-step"
@@ -49,6 +62,10 @@
                           [canExit]="categoryStep.save"
                           stepTitle="{{ categoryStep.title }}"
                           navigationSymbol="{{ categoryStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': categoryStep.isStepComplete()}">4</span>
+      {{ categoryStep.title }}
+    </ng-template>
   </app-action-category-step>
 
   <app-action-funding-step class="wizard-step"
@@ -58,6 +75,10 @@
                           [canExit]="fundingStep.save"
                           stepTitle="{{ fundingStep.title }}"
                           navigationSymbol="{{ fundingStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': fundingStep.isStepComplete()}">5</span>
+      {{ fundingStep.title }}
+    </ng-template>
   </app-action-funding-step>
 
   <app-action-review-step class="wizard-step"
@@ -66,6 +87,10 @@
                           enableBackLinks
                           stepTitle="{{ reviewStep.title }}"
                           navigationSymbol="{{ reviewStep.navigationSymbol }}">
+    <ng-template wizardStepTitle>
+      <span class="step-number" [ngClass]="{'complete': allStepsCompleted()}">6</span>
+      {{ reviewStep.title }}
+    </ng-template>
   </app-action-review-step>
 
 </wizard>

--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
@@ -58,4 +58,10 @@ export class ActionWizardComponent implements AfterViewInit, OnInit {
   // this.wizard.navigation and this.wizard.model are not available until this hook
   ngAfterViewInit() {}
 
+  allStepsCompleted(): boolean {
+    return this.assessStep.isStepComplete() && this.implementationStep.isStepComplete() &&
+      this.improvementsStep.isStepComplete() && this.categoryStep.isStepComplete() &&
+      this.fundingStep.isStepComplete();
+  }
+
 }

--- a/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
@@ -85,5 +85,9 @@ export class AssessStepComponent extends ActionWizardStepComponent<AssessStepFor
 
     return model;
   }
+
+  isStepComplete(): boolean {
+    return this.form.controls.name.valid;
+  }
 }
 

--- a/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
@@ -21,7 +21,7 @@ export class CategoryStepComponent extends ActionWizardStepComponent<ActionCateg
   public title = 'Categories';
   public key = ActionStepKey.Category;
 
-  public actionCategories: ActionCategory[];
+  public actionCategories: ActionCategory[] = [];
 
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
@@ -92,6 +92,10 @@ export class CategoryStepComponent extends ActionWizardStepComponent<ActionCateg
   toModel(data: ActionCategory[], model: Action): Action {
     model.categories = data;
     return model;
+  }
+
+  isStepComplete() {
+    return this.getFormModel().length > 0;
   }
 
 }

--- a/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.ts
@@ -60,4 +60,8 @@ export class FundingStepComponent extends ActionWizardStepComponent<FundingStepF
     model.funding = data.funding;
     return model;
   }
+
+  isStepComplete() {
+    return !!this.form.controls.funding.value;
+  }
 }

--- a/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.ts
@@ -94,4 +94,8 @@ export class ImplementationStepComponent
     this.form.controls.isPublic.setValue(value);
     this.form.controls.isPublic.markAsDirty();
   }
+
+  isStepComplete() {
+    return !!this.form.controls.action_goal.value && !!this.form.controls.action_type.value;
+  }
 }

--- a/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.ts
@@ -81,4 +81,9 @@ export class ImprovementsStepComponent
     model.improvements_impacts = data.improvements_impacts;
     return model;
   }
+
+  isStepComplete() {
+    return !!this.form.controls.improvements_adaptive_capacity.value &&
+      !!this.form.controls.improvements_impacts.value;
+  }
 }


### PR DESCRIPTION
## Overview

Similar to #595, allows access to any step of the action wizard and indicates which step is complete in the navigation bar on the left. There are no required fields to create a new action (besides risk), so we don't have to disable form fields as was needed on the risk wizard.

### Demo

![screenshot from 2018-02-08 18-13-30](https://user-images.githubusercontent.com/4432106/36003678-13e4aa3c-0cfd-11e8-981c-23edb7bb726a.png)


### Notes

 - I picked which fields are required for the first 3 steps to be consider complete based on https://github.com/azavea/temperate/blob/767c568610b316df8ca1895838de7774d94369f7/src/angular/planit/src/app/shared/models/action.model.ts#L28-L38
 - Picking any category marks that step as complete, and filling in the textarea marks the funding step as complete


## Testing Instructions

 * `./scripts/server`
 * Adding a new action should continue to work
 * Editing an existing action should continue to work
 * Steps should be marked as complete in the wizard navbar as appropriate

Closes #574
