### PR TITLE
Top concern boxes shouldn't overflow their parent container

### DIFF
--- a/src/angular/planit/src/assets/sass/components/_top-concern.scss
+++ b/src/angular/planit/src/assets/sass/components/_top-concern.scss
@@ -1,12 +1,12 @@
 .top-concerns {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .concern {
   position: relative;
-  flex: 0 0 32%;
-  margin: 0.5%;
+  flex: 0 0 32.66%;
+  margin: 0.33%;
   position: relative;
 
   &:last-child {


### PR DESCRIPTION
## Overview
Top concern boxes were overflowing their 

Closes #251

### Demo
![screen shot 2018-02-09 at 9 41 27 am](https://user-images.githubusercontent.com/5672295/36032937-89168048-0d7d-11e8-8f0c-c556c16c7899.png)
![screen shot 2018-02-09 at 9 41 12 am](https://user-images.githubusercontent.com/5672295/36032938-892103ce-0d7d-11e8-9f04-0b8cfc56eeb9.png)
![screen shot 2018-02-09 at 9 42 45 am](https://user-images.githubusercontent.com/5672295/36032955-9df43bcc-0d7d-11e8-9ca0-2fabffd1e38b.png)

### Notes
- I couldn't seem to test this in IE11, but it does work in Edge, Firefox, Chrome and Safari. In IE11 (using Browserstack) the page wouldn't load (bug entered: #611) 
- Right now we don't have an empty state. We will have one for community systems, and should build the hazard equivalent (see the "None yet" text here: https://github.com/azavea/temperate/issues/489)
