### PR TITLE
Set short cache timeout in Vagrant NFS options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,9 +6,9 @@ Vagrant.require_version ">= 1.8"
 TEMPERATE_SHARED_FOLDER_TYPE = ENV.fetch("TEMPERATE_SHARED_FOLDER_TYPE", "nfs")
 if TEMPERATE_SHARED_FOLDER_TYPE == "nfs"
   if Vagrant::Util::Platform.linux? then
-    TEMPERATE_MOUNT_OPTIONS = ['rw', 'vers=3', 'tcp', 'nolock']
+    TEMPERATE_MOUNT_OPTIONS = ['rw', 'vers=3', 'tcp', 'nolock', 'actimeo=1']
   else
-    TEMPERATE_MOUNT_OPTIONS = ['vers=3', 'udp']
+    TEMPERATE_MOUNT_OPTIONS = ['vers=3', 'udp', 'actimeo=1']
   end
 else
   if ENV.has_key?("TEMPERATE_MOUNT_OPTIONS")


### PR DESCRIPTION
## Overview

Sets the attribute cache timeout for NFS linked directories to 1 second.  This helps with the long wait time for the watcher to notice file changes and rebuild.

## Testing Instructions

Start or restart your VM with the updated Vagrantfile.  Everything should continue to work fine, and saving a file should make "webpack: Compiling..." appear immediately or almost immediately, rather than between several and dozens of seconds later.

Resolves #587.