### PR TITLE
Filter by hazard when exiting action wizard

### DIFF
--- a/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
@@ -55,10 +55,11 @@ export class AssessStepComponent extends ActionWizardStepComponent<AssessStepFor
         'risk': risk,
         'name': `${risk.weather_event.name} on ${risk.community_system.name}`};
     });
-}
+  }
 
   cancel () {
-    this.router.navigate(['actions']);
+    this.router.navigate(['actions'],
+      {'queryParams': {'hazard': this.namedRisk.risk.weather_event.id}});
   }
 
   fromModel(action: Action): AssessStepFormModel {
@@ -90,4 +91,3 @@ export class AssessStepComponent extends ActionWizardStepComponent<AssessStepFor
     return this.form.controls.name.valid;
   }
 }
-

--- a/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.ts
@@ -66,7 +66,7 @@ export class ReviewStepComponent extends ActionWizardStepComponent<any>
   }
 
   finish() {
-    this.router.navigate(['actions']);
+    this.router.navigate(['actions'], {'queryParams': {'hazard': this.risk.weather_event.id}});
   }
 
   getFormModel() {


### PR DESCRIPTION
## Overview
Currently, users are intended to reach the Actions list page in the context of a Hazard. There is no navigation bar link to the Actions page - instead, the user is expected to reach the page via the Dashboard by clicking "Take action" for a specific hazard.

This relationship was not persisted when editing an action, however, and after exiting the action wizard (Either by clicking Cancel or Finish), the user would be returned to see a list of all actions for all weather events.

This changes that to make the presentation of actions behave consistently.

### Note
Since it doesn't appear to be desired for the actions list to be shown without filtering by hazard, it may be worthwhile to at some point refactor so hazard ID is a necessary component rather than provided as an optional query parameter.

## Testing Instructions
- Navigate to the Action list page
- Click "Edit" from the dropdown menu to open the Action Wizard for an action
- In the "General Information" tab, click "Cancel"
  - You should be directed to a URL ending with `...?hazard=XXX`, and should only see actions related to the hazard
- Repeat by clicking "View" to open the for the "Review" step and clicking the "Finish" button 

Closes #615 
