### PR TITLE
View risk link should go to last step of wizard

### DIFF
--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -65,7 +65,7 @@
                 </button>
                 <ul *dropdownMenu class="dropdown-menu dropdown-menu-right" role="menu">
                   <li role="menuitem">
-                    <a class="dropdown-item" [routerLink]="['risk', risk.id]">View</a>
+                    <a class="dropdown-item" [routerLink]="['risk', risk.id]" [queryParams]="{goToStep:4}">View</a>
                   </li>
                   <li role="menuitem">
                     <a class="dropdown-item" [routerLink]="['risk', risk.id]">Edit</a>

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
@@ -11,7 +11,8 @@
         navigationMode="free"
         navBarLocation="left"
         navBarLayout="large-filled-symbols"
-        class="custom-steps">
+        class="custom-steps"
+        [defaultStepIndex]="startingStep">
   <app-risk-step-identify class="wizard-step"
                           #identifyStep
                           wizardStep

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
@@ -4,6 +4,7 @@ import { AfterViewChecked,
          Input,
          OnInit,
          ViewChild } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
 
 // Import from root doesn't seem to pickup types, so import directly from file
 import { WizardComponent } from 'ng2-archwizard/dist/components/wizard.component';
@@ -34,8 +35,11 @@ export class RiskWizardComponent implements OnInit, AfterViewChecked {
 
   @Input() risk: Risk;
 
+  public startingStep = 0;
+
   constructor(private session: WizardSessionService<Risk>,
-              private changeDetector: ChangeDetectorRef) {}
+    private changeDetector: ChangeDetectorRef,
+    private activatedRoute: ActivatedRoute) {}
 
   ngAfterViewChecked() {
     this.changeDetector.detectChanges();
@@ -49,5 +53,9 @@ export class RiskWizardComponent implements OnInit, AfterViewChecked {
       });
     }
     this.session.setData(this.risk);
+
+    this.activatedRoute.queryParams.subscribe((params: Params) => {
+      this.startingStep = params['goToStep'] || 0;
+    });
   }
 }


### PR DESCRIPTION
## Overview

When the user clicks the view link for a risk on the assessment overview page, it now goes to the last step of the risk wizard. This is opposed to the edit link, which goes to the first step of the risk wizard.

To achieve this, a query parameter that indicates which step to go to is added to the view link.

### Demo

![feb-13-2018 10-48-16](https://user-images.githubusercontent.com/1042475/36158920-80e8a028-10ab-11e8-9a3d-a420b214c5f4.gif)

### Notes

~~There is a short flash of the first step of the wizard. I couldn't find a way around this, but I'm open to ideas.~~

## Testing Instructions

- Visit the vulnerability assessment page.
- For a risk, open the `...` menu, and click the "View" link.
- Verify that it opens the risk wizard and proceeds to the last step.

Closes #520