### PR TITLE
Dynamically change label and location of settings back button

### DIFF
--- a/src/angular/planit/src/app/app.module.ts
+++ b/src/angular/planit/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { DownloadService } from './core/services/download.service';
 import { MarketingAuthGuard } from './core/services/marketing-auth-guard.service';
 import { OrganizationService } from './core/services/organization.service';
 import { PlanAuthGuard } from './core/services/plan-auth-guard.service';
+import { PreviousRouteGuard } from './core/services/previous-route-guard.service';
 import { RelatedAdaptiveValueService } from './core/services/related-adaptive-value.service';
 import { RiskService } from './core/services/risk.service';
 import { SuggestedActionService } from './core/services/suggested-action.service';
@@ -123,6 +124,7 @@ import { AppRoutingModule } from './app-routing.module';
     MarketingAuthGuard,
     OrganizationService,
     PlanAuthGuard,
+    PreviousRouteGuard,
     RelatedAdaptiveValueService,
     RiskResolve,
     RiskService,

--- a/src/angular/planit/src/app/core/services/previous-route-guard.service.ts
+++ b/src/angular/planit/src/app/core/services/previous-route-guard.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs/Rx';
+
+import { PlanAuthGuard } from './plan-auth-guard.service';
+
+/**
+ * Stores the URL of the previous route
+ *
+ * Should only be used by routes which have this as a guard,
+ * and should always be used in conjunction with another guard
+ * as the last guard in the list if the page should not always be accessible.
+ *
+ * e.g.
+ *
+ * { path: 'hello', component: HelloComponent, canActivate: [AuthGuard, PreviousRouteGuard] }
+ *
+ **/
+@Injectable()
+export class PreviousRouteGuard implements CanActivate {
+
+  private url = '';
+  private params = {};
+
+  constructor(private planAuthGuard: PlanAuthGuard,
+              private router: Router) { }
+
+  canActivate(route: ActivatedRouteSnapshot): boolean {
+    // Angular doesn't want to let you route to a URL with embedded query
+    // parameters, so we need to get and store the path separately from the
+    // query params
+    const urlTree = this.router.parseUrl(this.router.url);
+    this.url = this.urlTreePath(urlTree);
+    this.params = urlTree.queryParams;
+    return true;
+  }
+
+  get previousUrl() {
+    return this.url;
+  }
+
+  get previousQueryParams() {
+    return this.params;
+  }
+
+  get previousPage() {
+    if (!this.url) {
+      return null;
+    }
+
+    const labels = [
+      ['/actions/action/new', 'Add Adaptation Action'],
+      ['/actions/action/', 'Edit Adaptation Action'],
+      ['/actions', 'Adaptation Actions'],
+      ['/assessment/risk/new', 'Add Risk'],
+      ['/assessment/risk/', 'Edit Risk'],
+      ['/assessment', 'Vulnerability Assessment'],
+      ['/dashboard', 'Dashboard'],
+      ['/city-profile', 'City Profile'],
+      ['/indicators', 'Indicators'],
+      ['/settings', 'Settings'],
+      ['/', 'Home']
+    ];
+
+    for (const [path, label] of labels) {
+      if (this.url.startsWith(path)) {
+        return label;
+      }
+    }
+  }
+
+  private urlTreePath(urlTree: UrlTree): string {
+    if (urlTree.root.children.primary) {
+      return '/' + urlTree.root.children.primary.segments.map(s => s.path).join('/');
+    }
+    return '/';
+  }
+}

--- a/src/angular/planit/src/app/settings/settings-routing.module.ts
+++ b/src/angular/planit/src/app/settings/settings-routing.module.ts
@@ -2,10 +2,13 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
 import { PlanAuthGuard } from '../core/services/plan-auth-guard.service';
+import { PreviousRouteGuard } from '../core/services/previous-route-guard.service';
 import { SettingsComponent } from './settings.component';
 
 const routes: Routes = [
-  { path: 'settings', component: SettingsComponent, canActivate: [PlanAuthGuard] },
+  { path: 'settings', component: SettingsComponent,
+    canActivate: [PlanAuthGuard, PreviousRouteGuard]
+  },
 ];
 
 @NgModule({

--- a/src/angular/planit/src/app/settings/settings.component.html
+++ b/src/angular/planit/src/app/settings/settings.component.html
@@ -1,7 +1,7 @@
 <div class="main-container">
   <main class="main-content" role="main">
     <header>
-      <a href="javascript:">Back</a>
+      <a [routerLink]="[previousUrl]" [queryParams]="previousParams" *ngIf="previousPage">Back to {{ previousPage }}</a>
       <h1 class="heading">Settings</h1>
     </header>
     <section>

--- a/src/angular/planit/src/app/settings/settings.component.ts
+++ b/src/angular/planit/src/app/settings/settings.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { PreviousRouteGuard } from './../core/services/previous-route-guard.service';
+
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
@@ -7,9 +9,16 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SettingsComponent implements OnInit {
 
-  constructor() { }
+  public previousPage = 'Home';
+  public previousUrl = '/';
+  public previousParams = {};
+
+  constructor(private previousRouteGuard: PreviousRouteGuard) { }
 
   ngOnInit() {
+    this.previousUrl = this.previousRouteGuard.previousUrl;
+    this.previousPage = this.previousRouteGuard.previousPage;
+    this.previousParams = this.previousRouteGuard.previousQueryParams;
   }
 
 }

--- a/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.html
+++ b/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.html
@@ -10,7 +10,7 @@
       </a>
     </li>
     <li role="menuitem">
-      <a class="dropdown-item" href="javascript:" routerLink="/settings">
+      <a class="dropdown-item" href="javascript:" routerLink="/settings" routerLinkActive="disabled">
         <i class="icon-cog"></i> Settings
       </a>
     </li>


### PR DESCRIPTION
## Overview

Sets the "Back to X" link on the settings page dynamically based on the previous page.


### Demo

![screenshot from 2018-02-13 16-28-51](https://user-images.githubusercontent.com/4432106/36174687-fe4edd3c-10da-11e8-923b-15a2d10da42c.png)


### Notes

We'll want this behaviour on other pages (see #627) so I've broken this out into it's own PR.


## Testing Instructions

 * Make sure going to `/settings` directly works (it should link "back" to the homepage)
 * Ensure the back link works correctly for nested routes (`/actions` should be recognized as a different page from `/actions/new`)
 * Ensure query parameters are preserved, such as on the filtered Assessment overview page

Connects to #533
