### PR TITLE
Bump Vagrant VM memory to 3GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", type: TEMPERATE_SHARED_FOLDER_TYPE, mount_options: TEMPERATE_MOUNT_OPTIONS
 
   config.vm.provider :virtualbox do |vb|
-    vb.memory = 2048
+    vb.memory = 3072
     vb.cpus = 2
   end
 


### PR DESCRIPTION
Chromium Angular tests would consistently fail when run
via ./scripts/test while ./scripts/server was running.

Bumping overall memory seems to relieve memory pressure
enough to allow both scripts to consistently be run
at the same time.

@fungjj92 you mentioned open issues that mention this problem, but I was unable to find any. If you saw a particular one, can you link it here?

From @fungjj92:
https://github.com/karma-runner/karma/issues/2652
https://github.com/karma-runner/karma-chrome-launcher/issues/154

## Testing

Pull this branch down, then run `vagrant reload` on your host, then SSH in and run `./scripts/test` and `./scripts/server` at the same time in separate shells. `./scripts/test` should now run successfully and _not_ hang when starting chromium during angular tests.
