### PR TITLE
Redirect activated user to new login page

### DIFF
--- a/src/angular/planit/src/app/app-routing.module.ts
+++ b/src/angular/planit/src/app/app-routing.module.ts
@@ -3,11 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { environment } from '../environments/environment';
 
-import { MarketingAuthGuard } from './core/services/marketing-auth-guard.service';
+import { LoggedInAuthGuard } from './core/services/logged-in-auth-guard.service';
 import { PlanAuthGuard } from './core/services/plan-auth-guard.service';
 import { PreviousRouteGuard } from './core/services/previous-route-guard.service';
 import { UserResolve } from './core/services/user.resolve';
 import { CreatePlanComponent } from './create-plan/create-plan.component';
+import { LoginPageComponent } from './login-page/login-page.component';
 import { ManageSubscriptionComponent } from './marketing/manage-subscription.component';
 import { MarketingComponent } from './marketing/marketing.component';
 import { MethodologyComponent } from './marketing/methodology.component';
@@ -16,7 +17,7 @@ import { OrganizationWizardComponent } from './organization-wizard/organization-
 
 const routes: Routes = [
   { path: 'reset-password/:token', component: MarketingComponent},
-  { path: '', component: MarketingComponent, canActivate: [MarketingAuthGuard] },
+  { path: '', component: MarketingComponent, canActivate: [LoggedInAuthGuard] },
   {
     path: 'plan',
     component: CreatePlanComponent,
@@ -24,6 +25,7 @@ const routes: Routes = [
     canActivate: [PlanAuthGuard]
   },
   { path: 'methodology', component: MethodologyComponent, canActivate: [PreviousRouteGuard] },
+  { path: 'login', component: LoginPageComponent, canActivate: [LoggedInAuthGuard] },
   {
     path: 'subscription',
     component: ManageSubscriptionComponent,

--- a/src/angular/planit/src/app/app.module.ts
+++ b/src/angular/planit/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { environment } from '../environments/environment';
 
 import { AppComponent } from './app.component';
+import { LoginPageComponent } from './login-page/login-page.component';
 import { ManageSubscriptionComponent } from './marketing/manage-subscription.component';
 import { MarketingComponent } from './marketing/marketing.component';
 import { MethodologyComponent } from './marketing/methodology.component';
@@ -43,7 +44,7 @@ import { CityService } from './core/services/city.service';
 import { CollaboratorService } from './core/services/collaborator.service';
 import { CommunitySystemService } from './core/services/community-system.service';
 import { DownloadService } from './core/services/download.service';
-import { MarketingAuthGuard } from './core/services/marketing-auth-guard.service';
+import { LoggedInAuthGuard } from './core/services/logged-in-auth-guard.service';
 import { OrganizationService } from './core/services/organization.service';
 import { PlanAuthGuard } from './core/services/plan-auth-guard.service';
 import { PreviousRouteGuard } from './core/services/previous-route-guard.service';
@@ -71,6 +72,7 @@ import { AppRoutingModule } from './app-routing.module';
   declarations: [
     AppComponent,
     ManageSubscriptionComponent,
+    LoginPageComponent,
     MarketingComponent,
     MethodologyComponent,
     PageNotFoundComponent
@@ -126,7 +128,7 @@ import { AppRoutingModule } from './app-routing.module';
     CollaboratorService,
     CommunitySystemService,
     DownloadService,
-    MarketingAuthGuard,
+    LoggedInAuthGuard,
     OrganizationService,
     PlanAuthGuard,
     PreviousRouteGuard,

--- a/src/angular/planit/src/app/core/services/logged-in-auth-guard.service.ts
+++ b/src/angular/planit/src/app/core/services/logged-in-auth-guard.service.ts
@@ -6,15 +6,15 @@ import { ActivatedRouteSnapshot,
 import { AuthService } from './auth.service';
 
 @Injectable()
-export class MarketingAuthGuard implements CanActivate {
+export class LoggedInAuthGuard implements CanActivate {
 
   constructor(private authService: AuthService,
               private router: Router) {}
 
-  /* We want authenticated users to be redirected to the dashboard from '/' but unauthenticated
-     users to go to the marketing page. To let authenticated users still access the marketing page
-     when they explicitly click a link to go there we need to add a ref to the link and check for
-     it here. Behavior designed after printful.com */
+  /* We want authenticated users to be redirected to the dashboard from '/' or `/login` but
+     unauthenticated users to go to the marketing page. To let authenticated users still access
+     the marketing page when they explicitly click a link to go there we need to add a ref to
+     the link and check for it here. Behavior designed after printful.com */
   canActivate(route: ActivatedRouteSnapshot): boolean {
     const loggedIn = this.authService.isAuthenticated();
     if (loggedIn && !route.url[0] && route.queryParams.ref === 'footer') {

--- a/src/angular/planit/src/app/login-page/login-page.component.html
+++ b/src/angular/planit/src/app/login-page/login-page.component.html
@@ -1,0 +1,10 @@
+<main class="main-content login-page" role="main">
+  <section class="container-standard">
+    <div class="container-content">
+      <div *ngIf="activated" class="alert alert-positive">
+        Your Temperate account is now active. Login to get started.
+      </div>
+      <app-login-form></app-login-form>
+    </div>
+  </section>
+</main>

--- a/src/angular/planit/src/app/login-page/login-page.component.ts
+++ b/src/angular/planit/src/app/login-page/login-page.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login-page',
+  templateUrl: './login-page.component.html'
+})
+export class LoginPageComponent implements OnInit {
+
+  public activated: Boolean = false;
+
+  constructor(private activatedRoute: ActivatedRoute,
+              private router: Router) {}
+
+  ngOnInit() {
+    this.activatedRoute.queryParamMap.subscribe(paramsAsMap => {
+      if (paramsAsMap['params']['activated']) {
+        this.activated = true;
+      }
+    });
+  }
+
+}

--- a/src/angular/planit/src/app/shared/login-form/login-form.component.html
+++ b/src/angular/planit/src/app/shared/login-form/login-form.component.html
@@ -1,7 +1,5 @@
 <div class="modal-header">
   <h1>Log Into Your Account</h1>
-  <button type="button" class="button button-modal-close"
-      (click)="closeModal()" aria-label="Close"><i class="icon-cancel"></i></button>
 </div>
 <div class="modal-body">
   <form class="form" id="form-login">
@@ -44,8 +42,6 @@
 </div>
 <div class="modal-footer">
   <div class="button-group">
-    <button type="button" class="button button-small"
-        (click)="closeModal()" aria-label="Close">Cancel</button>
     <input type="submit" class="button button-primary button-small"
         (click)="submit()" value="Log In" form="form-login">
     <input type="submit" class="button button-primary button-small"

--- a/src/angular/planit/src/app/shared/navbar/navbar.component.html
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.html
@@ -12,7 +12,7 @@
     <button class="contact-iclei button button-primary button-small"
             (click)="openModal(newUserForm)">Create an Account</button>
     <button class="button button-small"
-            (click)="openModal(loginForm)">Log In</button>
+            routerLink="/login">Log In</button>
   </div>
 </header>
 
@@ -28,9 +28,4 @@
 <!-- Create Account Modal template -->
 <ng-template #newUserForm>
   <app-new-user-form (closed)="modalRef.hide()"></app-new-user-form>
-</ng-template>
-
-<!-- Login Modal template -->
-<ng-template #loginForm>
-  <app-login-form (closed)="modalRef.hide()"></app-login-form>
 </ng-template>

--- a/src/angular/planit/src/assets/sass/components/_alert.scss
+++ b/src/angular/planit/src/assets/sass/components/_alert.scss
@@ -17,6 +17,8 @@
 
 @include generate-alert(-warning, $brand-warning);
 
+@include generate-alert(-positive, $brand-positive);
+
 .alert-heading {
   font-size: $alert-heading-font-size;
   font-weight: $alert-heading-font-weight;

--- a/src/django/users/urls.py
+++ b/src/django/users/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include, url
 
 from users.views import (PlanitHomeView,
                          RegistrationView,
+                         ActivationView,
                          UserProfileView,
                          PasswordResetInitView,
                          PasswordResetView)
@@ -19,6 +20,9 @@ urlpatterns = [
     url(r'^password_reset/$',
         PasswordResetView.as_view(),
         name='password_reset'),
+    url(r'^activate/(?P<activation_key>[-:\w]+)/$',
+        ActivationView.as_view(),
+        name='registration_activate'),
     url(r'^api/new_token/', PlanitHomeView().new_token, name='new_token'),
     url(r'^api/$', PlanitHomeView.as_view(), name='planit_home'),
     url(r'^profile/$', UserProfileView.as_view(), name='edit_profile'),

--- a/src/django/users/views.py
+++ b/src/django/users/views.py
@@ -10,6 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
 from registration.backends.hmac.views import RegistrationView as BaseRegistrationView
+from registration.backends.hmac.views import ActivationView as BaseActivationView
 
 from rest_framework import status, mixins
 from rest_framework.authtoken.models import Token
@@ -25,6 +26,8 @@ from users.forms import UserForm, UserProfileForm, PasswordResetInitForm, Passwo
 from users.models import PlanItOrganization, PlanItUser
 from users.permissions import IsAuthenticatedOrCreate
 from users.serializers import OrganizationSerializer, UserSerializer, UserOrgSerializer
+
+from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
@@ -68,6 +71,10 @@ class PasswordResetView(JsonFormView):
         form.cleaned_data['user'].set_password(form.cleaned_data['password1'])
         form.cleaned_data['user'].save()
         return Response({'status': 'ok'})
+
+
+class ActivationView(BaseActivationView):
+    success_url = settings.PLANIT_APP_HOME + '/login?activated=true'
 
 
 class PlanitHomeView(LoginRequiredMixin, View):


### PR DESCRIPTION
## Overview

When a user activates their account, they are now redirected to a login page within the Angular app. Previously, they were routed to a page provided by the Django registration module.

This login page embeds the login modal that is used on the marketing page. If a logged in user tries to access the login page, they are redirected to the dashboard.

### Demo

![image](https://user-images.githubusercontent.com/1042475/36449314-7700db4a-1658-11e8-8a95-ed2e0c784755.png)

## Testing Instructions

- Visit the home page and create a new user.
- Go to the app console, grab the activation URL, and paste it into your browser (remember to drop the `s` from `https`).
- You should be redirected to a page with the login form and there should be a message saying your account is now activated.
- Try logging in. You should succeed.

Closes #605 