### PR TITLE
Fix help modal console error

### DIFF
--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
+import { AuthService } from '../../core/services/auth.service';
 import { UserService } from '../../core/services/user.service';
 import { User } from '../models/user.model';
 
@@ -17,13 +18,12 @@ export class HelpModalComponent implements OnInit {
 
   constructor(private modalService: BsModalService,
               public router: Router,
+              private authService: AuthService,
               private userService: UserService) {}
 
   ngOnInit() {
-    if (this.router.url !== '/?ref=footer' && this.router.url !== '/') {
-      this.userService.current().subscribe(u => {
-        this.user = u
-      });
+    if (this.authService.isAuthenticated()) {
+      this.userService.current().subscribe(u => this.user = u);
     }
     this.url = document.location.href;
   }


### PR DESCRIPTION
## Overview

A patch for the help modal where an unauthorized request could be sent to authService. On first glance I would have liked to put an *ngIf in the component tag `<app-help-modal></app-help-modal>` but the router at app level is not route aware.

### Demo
Not logged in, no error.

<img width="1043" alt="screen shot 2018-02-21 at 9 26 42 am" src="https://user-images.githubusercontent.com/10568752/36488385-4f7e6cba-16f1-11e8-949c-1fb2e88b1c40.png">

## Testing Instructions

Log out of everything (angular, django admin etc) and hit the marketing page. See no console errors
