### PR TITLE
Adapt action picker modal for no suggested actions

### DIFF
--- a/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.html
+++ b/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.html
@@ -3,7 +3,9 @@
         (click)="closeModal()" aria-label="Close">
         <i class="icon-cancel-circled2"></i>
 </button>
-<div class="action-picker-prompt" *ngIf="showPrompt">
+
+<!-- "How do you want to start?" prompt -->
+<div class="action-picker-prompt" *ngIf="showPrompt && suggestedActions.length > 0">
   <div class="modal-header action-picker-content">
     <h1 class="action-picker-header">How do you want to start?</h1>
   </div>
@@ -23,6 +25,26 @@
     </div>
   </div>
 </div>
+
+<!-- Alternate prompt when no actions were found -->
+<div class="action-picker-none" *ngIf="showPrompt && suggestedActions.length === 0">
+  <div class="modal-header action-picker-content">
+    <h1 class="action-picker-header">Develop a custom action step</h1>
+  </div>
+  <div class="container">
+    <div class="row justify-content-md-center action-picker-body">
+      <div class="modal-body">
+        <p class="action-picker-content">Sorry, we couldn't find any actions that matched this risk.
+                                         You can still develop a custom action step that addresses this risk.</p>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="button button-primary" (click)="goToWizard()">Get started</button>
+      <button class="button button-default" (click)="closeModal()">Cancel</button>
+    </div>
+  </div>
+</div>
+
 <!-- action picker (second dialog) -->
 <div class="action-picker" *ngIf="!showPrompt">
   <div class="action-picker-header">
@@ -59,8 +81,7 @@
       </div>
     </div>
     <div class="modal-footer">
-      <button class="button"
-              (click)="goToWizard()">Nevermind, I'll start from scratch</button>
+      <button class="button" (click)="goToWizard()">Nevermind, I'll start from scratch</button>
     </div>
   </div>
 </div>

--- a/src/angular/planit/src/assets/sass/components/action-steps/_action-picker.scss
+++ b/src/angular/planit/src/assets/sass/components/action-steps/_action-picker.scss
@@ -24,7 +24,7 @@
   }
 }
 
-.action-picker, .action-picker-prompt {
+.action-picker, .action-picker-prompt, .action-picker-none {
   .action-picker-content {
     text-align: center;
   }


### PR DESCRIPTION
## Overview

When we have no actions to suggest, we need to say so and send them to the creation wizard, rather than giving the option of clicking through to the empty list of recommendations.

This adds a third mode for the modal to show a message that we didn't find any suggested actions and a button to go to the action creation wizard.

### Demo

![image](https://user-images.githubusercontent.com/6598836/36541327-86e57da0-17ab-11e8-8c49-18b3caee8a5f.png)


### Notes

I wasn't sure from the issue whether this was supposed to have a layout closer to the existing "prompt" modal, with a lightbulb and the main body clickable.  But since the issue described a primary button and a cancel button, this more basic layout seemed to fit better.  Also the lightbulb makes more sense for "here are some ideas" than for "sorry, we don't have any ideas for you".

For reference, here's what the existing prompt modal looks like:
![image](https://user-images.githubusercontent.com/6598836/36541443-eaca01c4-17ab-11e8-902a-407e7cd67d9b.png)

And with the mouse-over shading:
![image](https://user-images.githubusercontent.com/6598836/36541504-1e8de71e-17ac-11e8-9692-1791e993ad81.png)

I can move the primary button up with the body and add the shading if that's preferable.

## Testing Instructions

- From the dashboard, click "Take Action" on a risk with no action steps, then click "Take Action" again on the card that shows up on the "Adaptation Actions" view.
- If there are no suggested actions in the database (I used "Forest Fire on Forestry"), it should show the new version of the modal.  "Get started" should go to the Take Action wizard, "Cancel" should go back to the Adaptation Actions view.

Closes #656.
