### PR TITLE
Always overwrite docker-compose.env.yml in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ node {
         }
 
         env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
-
+        env.JENKINS = "true"
+    
         // Execute `cibuild` wrapped within a plugin that translates
         // ANSI color codes to something that renders inside the Jenkins
         // console.

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -22,8 +22,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Create Django dockerfile only if it doesn't exist
-        if [ ! -f ./src/django/docker-compose.env ]
+        # Create Django dockerfile if it doesn't exist, or we're in CI
+        if [ ! -f ./src/django/docker-compose.env ] || [[ -n "${JENKINS}" ]];
         then
             cp ./src/django/docker-compose.env.example ./src/django/docker-compose.env
         fi


### PR DESCRIPTION
## Overview

Modify `scripts/cibuild` to always overwrite `docker-compose.env.yml` in CI so that new variables are included in the container environment. 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

See Jenkins output.
- The first commit introduces a new environment variable, which will break CI tests because it's not in `docker-compose.env.yml`. 
- The second commit introduces my fix. The environment file should be overwritten, and tests will pass. 
Closes #683 
