### PR TITLE
Update fixtures based on @jcahails modifications on staging

### DIFF
--- a/src/django/planit_data/fixtures/weathereventrank.json
+++ b/src/django/planit_data/fixtures/weathereventrank.json
@@ -145,15 +145,6 @@
 },
 {
     "model": "planit_data.weathereventrank",
-    "pk": 24,
-    "fields": {
-        "georegion": 26,
-        "weather_event": 17,
-        "order": 2
-    }
-},
-{
-    "model": "planit_data.weathereventrank",
     "pk": 25,
     "fields": {
         "georegion": 26,
@@ -186,15 +177,6 @@
         "georegion": 27,
         "weather_event": 3,
         "order": 1
-    }
-},
-{
-    "model": "planit_data.weathereventrank",
-    "pk": 29,
-    "fields": {
-        "georegion": 27,
-        "weather_event": 17,
-        "order": 2
     }
 },
 {
@@ -337,7 +319,7 @@
     "pk": 45,
     "fields": {
         "georegion": 30,
-        "weather_event": 2,
+        "weather_event": 20,
         "order": 2
     }
 },
@@ -366,6 +348,24 @@
         "georegion": 30,
         "weather_event": 5,
         "order": 5
+    }
+},
+{
+    "model": "planit_data.weathereventrank",
+    "pk": 49,
+    "fields": {
+        "georegion": 26,
+        "weather_event": 20,
+        "order": 2
+    }
+},
+{
+    "model": "planit_data.weathereventrank",
+    "pk": 50,
+    "fields": {
+        "georegion": 27,
+        "weather_event": 20,
+        "order": 2
     }
 }
 ]

--- a/src/django/planit_data/fixtures/weatherevents.json
+++ b/src/django/planit_data/fixtures/weatherevents.json
@@ -20,7 +20,7 @@
     "model": "planit_data.weatherevent",
     "pk": 2,
     "fields": {
-        "name": "Thunderstorms",
+        "name": "Lightning / Thunderstorm",
         "coastal_only": false,
         "concern": null,
         "display_class": "icon-lightning-thunderstorm",
@@ -49,7 +49,7 @@
     "model": "planit_data.weatherevent",
     "pk": 4,
     "fields": {
-        "name": "Surface floods",
+        "name": "Groundwater flooding",
         "coastal_only": false,
         "concern": null,
         "display_class": "icon-groundwater-flood",
@@ -88,14 +88,17 @@
         "coastal_only": true,
         "concern": null,
         "display_class": "icon-coastal-flood",
-        "indicators": []
+        "indicators": [
+            9,
+            22
+        ]
     }
 },
 {
     "model": "planit_data.weatherevent",
     "pk": 8,
     "fields": {
-        "name": "Hurricanes",
+        "name": "Cyclone (Hurricane / Typhoon)",
         "coastal_only": false,
         "concern": null,
         "display_class": "icon-hurricane",
@@ -226,20 +229,6 @@
 },
 {
     "model": "planit_data.weatherevent",
-    "pk": 17,
-    "fields": {
-        "name": "Extreme precipitation",
-        "coastal_only": false,
-        "concern": 22,
-        "display_class": "",
-        "indicators": [
-            9,
-            22
-        ]
-    }
-},
-{
-    "model": "planit_data.weatherevent",
     "pk": 18,
     "fields": {
         "name": "River flooding",
@@ -284,7 +273,7 @@
     "model": "planit_data.weatherevent",
     "pk": 21,
     "fields": {
-        "name": "Ice melt",
+        "name": "Extreme winter conditions",
         "coastal_only": false,
         "concern": null,
         "display_class": "",
@@ -333,10 +322,182 @@
     "model": "planit_data.weatherevent",
     "pk": 26,
     "fields": {
-        "name": "Flash / surface flood",
+        "name": "Flash / surface flooding",
         "coastal_only": false,
         "concern": 22,
         "display_class": "icon-flash-flood",
+        "indicators": [
+            9,
+            22
+        ]
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 27,
+    "fields": {
+        "name": "Monsoon",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 28,
+    "fields": {
+        "name": "Hail",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 29,
+    "fields": {
+        "name": "Severe wind",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 30,
+    "fields": {
+        "name": "Tornado",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 31,
+    "fields": {
+        "name": "Tropical storm",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": [
+            9
+        ]
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 32,
+    "fields": {
+        "name": "Extratropical storm",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": [
+            9
+        ]
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 33,
+    "fields": {
+        "name": "Fog",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 34,
+    "fields": {
+        "name": "Permanent inundation",
+        "coastal_only": true,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 35,
+    "fields": {
+        "name": "Atmospheric CO2 concentrations",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 36,
+    "fields": {
+        "name": "Avalanche",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 37,
+    "fields": {
+        "name": "Rockfall",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 38,
+    "fields": {
+        "name": "Water-borne disease",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 39,
+    "fields": {
+        "name": "Air-borne disease",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 40,
+    "fields": {
+        "name": "Vector-borne disease",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
+        "indicators": []
+    }
+},
+{
+    "model": "planit_data.weatherevent",
+    "pk": 41,
+    "fields": {
+        "name": "Insect infestation",
+        "coastal_only": false,
+        "concern": null,
+        "display_class": "",
         "indicators": []
     }
 }


### PR DESCRIPTION
This aligns our weather events more closely with those
determined to have value by CDP and Carbonn, rather
than statesatrisk.org

### Demo

N/A

### Notes

The data destruction described below should be a once-off thing. In the future, we'll likely want to only ever "deactivate" weather events rather than destroy them completely. This will make keeping the fixtures in sync across environments easier, and prevent data loss. I opened #695 to address this later.

~Per a discussion with @fungjj92 we'll also need to add a new issue to go back through our missy dataset csvs and update any weather event associations that are now broken.~ Created #695

Edit by @fungjj92: I picked through Missy's dataset and turns out Deb used the Carbonn weather events to categorize, so actually we're ok for now.

## Testing Instructions

1. Delete all existing WeatherEventRank and WeatherEvent objects in a Django shell:
 - `WeatherEventRank.objects.all().delete()`
 - `WeatherEvent.objects.all().delete()`
1. Stop your dev server then run `./scripts/update`
1. Verify that the fixtures loaded for all models in the Django admin now match the values in staging

Optionally re-create your VM to test that the "load from scratch" option works as expected.
