### PR TITLE
Allow renaming organizations

### DIFF
--- a/src/django/users/serializers.py
+++ b/src/django/users/serializers.py
@@ -83,7 +83,6 @@ class OrganizationSerializer(serializers.ModelSerializer):
         return instance
 
     def update(self, instance, validated_data):
-        validated_data.pop('name')
         location_data = validated_data.pop('location')
         for k, v in validated_data.items():
             setattr(instance, k, v)


### PR DESCRIPTION
## Overview
Removes the server-side block of renaming organizations, allowing user changes to organization name to persist after the page is reloaded.

## Testing Instructions
- Open the Settings page
- Click the "Edit" icon for the "Organization/department" field, enter a new value, and click "Save"
- Refresh the page
  - Your changed value should still be there on the refreshed page

Closes #682 
