### PR TITLE
Fix default dropdown menu placement

### DIFF
--- a/src/angular/planit/src/assets/sass/components/_dropdown.scss
+++ b/src/angular/planit/src/assets/sass/components/_dropdown.scss
@@ -25,7 +25,7 @@
 .dropdown-menu {
   position: absolute;
   top: 100%;
-  right: 0;
+  left: 0;
   z-index: $zindex-dropdown-menu;
   display: none;
   float: left;


### PR DESCRIPTION
## Overview
Removing the bootstrap styles for dropdowns (which were already copied into `_dropdownscss`) caused the dropdown menu to float in the wrong place. This should be fixed in all areas (key ones highlighted below).

### Demo
<img width="841" alt="screen shot 2018-02-27 at 10 06 18 am" src="https://user-images.githubusercontent.com/5672295/36736331-585a9d18-1ba6-11e8-9bc9-860af352b4c5.png">
<img width="865" alt="screen shot 2018-02-27 at 10 07 32 am" src="https://user-images.githubusercontent.com/5672295/36736332-586cbdae-1ba6-11e8-853e-e41a6e93d651.png">
<img width="865" alt="screen shot 2018-02-27 at 10 07 35 am" src="https://user-images.githubusercontent.com/5672295/36736333-58ce551e-1ba6-11e8-9aa8-8b4ec423d217.png">
<img width="865" alt="screen shot 2018-02-27 at 10 07 22 am" src="https://user-images.githubusercontent.com/5672295/36737468-1f539b0c-1ba9-11e8-9f78-022774461897.png">


### Notes
- Bootstrap styles had already been copied over into a dropdown file, so I thought commenting it out was safe. Looks like we had `right: 0` when it should have been `left: 0`. Bootstrap was adding the latter which made these look correct. I didn't _notice_ any issue with leaving `right: 0` out of the mix.

Closes #698
