### PR TITLE
Add take action button on assessment overview page

### DIFF
--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -80,6 +80,12 @@
         </tbody>
       </table>
       <button class="button" routerLink="risk/new">Add new risk</button>
+      <button class="button button-positive"
+              *ngIf="risks?.length && getAssessedRisks().length >= 1"
+              [routerLink]="['/actions']"
+              [queryParams]="{hazard: weatherEvent?.id}">
+        Take action
+      </button>
     </section>
   </main>
 </div>

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.ts
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.ts
@@ -47,4 +47,8 @@ export class AssessmentOverviewComponent implements OnInit {
       this.risks = this.risks.filter(r => r.id !== risk.id);
     });
   }
+
+  getAssessedRisks() {
+    return this.risks.filter(r => r.isAssessed());
+  }
 }


### PR DESCRIPTION
## Overview

Add a button that takes users to the action overview page for the given hazard.

### Demo

![image](https://user-images.githubusercontent.com/1042475/36747757-dc6b7b78-1bc3-11e8-8f00-4aedbce20ce9.png)

## Testing Instructions

- Visit the dashboard.
- Click the "Assess" button for one of the group of risks where there is at least one assessed risk.
- There should be a "Take Action" button under the list of risks.
- Clicking the button should take you to the action overview page for just the respective hazard.

Closes #649