### PR TITLE
Set created_at date for test organizations

### DIFF
--- a/src/django/users/fixtures/test_organizations.json
+++ b/src/django/users/fixtures/test_organizations.json
@@ -8,10 +8,12 @@
         "location": [
             7
         ],
+        "created_at": "2018-02-28",
         "created_by": null,
         "plan_due_date": "2023-02-01",
         "plan_name": "",
-        "plan_hyperlink": ""
+        "plan_hyperlink": "",
+        "community_systems": []
     }
 },
 {
@@ -23,10 +25,12 @@
         "location": [
             1
         ],
+        "created_at": "2018-02-28",
         "created_by": null,
         "plan_due_date": "2022-02-01",
         "plan_name": "",
-        "plan_hyperlink": ""
+        "plan_hyperlink": "",
+        "community_systems": []
     }
 },
 {


### PR DESCRIPTION
## Overview

Fixes test organization data not loading from fixture.


### Notes

`created_at` field added in #644.


## Testing Instructions

 * Delete any existing test organizations
 * `./scripts/manage loaddata test_organizations`
 * Should succeed

Fixes #717 
