### PR TITLE
Check result of risk save

### DIFF
--- a/src/angular/planit/src/app/risk-wizard/risk-wizard-step.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard-step.component.ts
@@ -41,12 +41,14 @@ export abstract class RiskWizardStepComponent<FormModel>
 
 
   finish() {
-    // ng2-archwizard save() takes a direction, like forward or back,
-    // but we're not going in any direction when exiting
-    this.save(undefined).then(() => {
-      const risk = this.session.getData();
-      this.router.navigate(['assessment'],
-        {'queryParams': {'hazard': risk.weather_event.id}});
+    this.save().then((succeeded) => {
+      if (succeeded) {
+        const risk = this.session.getData();
+        this.router.navigate(['assessment'],
+          {'queryParams': {'hazard': risk.weather_event.id}});
+      } else {
+        this.cancel();
+      }
     });
   }
 


### PR DESCRIPTION
## Overview

Check whether saving risk was successful before redirecting. If it failed, cancel instead of redirecting to filtered hazard list.

## Testing Instructions

 * Attempt to change an existing risk to set the hazard to a conflicting hazard
 * Click 'Finish later'
 * Should get error popup and be redirected back to last page
 * Successful save should continue to work as expected (redirect to filtered hazard list)

Closes #681.
