### PR TITLE
Hide menu links until user selects an organization

### DIFF
--- a/src/angular/planit/src/app/shared/navbar/navbar.component.html
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.html
@@ -3,6 +3,7 @@
   <a *ngIf="router.url === '/'" routerLink="/" class="logo"><img src="assets/images/temperate-logo-white.svg" alt="Temperate, by Azavea"></a>
   <div class="nav-buttons" *ngIf="authService.isAuthenticated()">
     <a class="button button-inverse-light"
+       *ngIf="showLink('/dashboard')"
        routerLink="/dashboard" >Dashboard</a>
     <a class="button button-inverse-light"
        *ngIf="showLink('/indicators')"

--- a/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.html
+++ b/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.html
@@ -9,12 +9,12 @@
       <div class="subscription">{{ subscriptionOptions.get(user.primary_organization?.subscription) }}</div>
     </li>
     <li role="separator" class="divider"></li>
-    <li role="menuitem">
+    <li *ngIf="organization?.id" role="menuitem">
       <a routerLink="/subscription">Upgrade your plan</a>
     </li>
     <li role="separator" class="divider"></li>
     <li role="menuitem">
-      <a href="javascript:" routerLink="/settings" routerLinkActive="disabled">
+      <a *ngIf="organization?.id" href="javascript:" routerLink="/settings" routerLinkActive="disabled">
         <i class="icon-cog"></i>
         Settings
       </a>

--- a/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.ts
+++ b/src/angular/planit/src/app/shared/user-dropdown/user-dropdown.component.ts
@@ -1,22 +1,33 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+
+import { Subscription } from 'rxjs/Rx';
 
 import { AuthService } from '../../core/services/auth.service';
 import { UserService } from '../../core/services/user.service';
-import { OrgSubscriptionOptions, User } from '../../shared';
+import { OrgSubscriptionOptions, Organization, User } from '../../shared';
 
 @Component({
   selector: 'app-user-dropdown',
   templateUrl: './user-dropdown.component.html'
 })
 
-export class UserDropdownComponent implements OnInit {
+export class UserDropdownComponent implements OnDestroy, OnInit {
   public user: User;
+  public organization: Organization;
   public subscriptionOptions = OrgSubscriptionOptions;
+  public userSubscription: Subscription;
 
   constructor(private authService: AuthService, private userService: UserService) {}
 
   ngOnInit() {
-    this.userService.current().subscribe(user => this.user = user);
+    this.userSubscription = this.userService.currentUser.subscribe(user => {
+      this.user = user;
+      this.organization = user.primary_organization;
+    });
+  }
+
+  ngOnDestroy() {
+    this.userSubscription.unsubscribe();
   }
 
   public logout() {


### PR DESCRIPTION
## Overview

To avoid issues with letting users access their settings page before their account is fully setup, the links to these pages are hidden in the user menu until an organization is selected by the user.

### Demo

![mar-01-2018 14-57-40](https://user-images.githubusercontent.com/1042475/36866684-feb0cd0c-1d60-11e8-9212-4f2798e525a9.gif)

## Testing Instructions

- Create a new user.
- Login with the new user.
- Before filling out any of the forms, check that the "Settings" and "Upgrade your plan" options are not displayed in the user menu. Also the dashboard and indicator buttons should be hidden as well.
- Select an organization and proceed to the dashboard.
- Verify that the "Settings" and "Upgrade your plan" options are now displayed in the user menu. 

Closes #676 