### PR TITLE
Fix user support check for users w/o organizations

### DIFF
--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
@@ -60,7 +60,7 @@ export class HelpModalComponent implements OnInit, OnDestroy {
   }
 
   public hasSupport() {
-    if (this.user) {
+    if (this.user && this.user.primary_organization) {
       return this.user.primary_organization.hasSupport();
     }
 


### PR DESCRIPTION
## Overview

If a user has no organization, they are technically not eligible for support yet.

## Notes

- Discovered this while testing out `develop` after merging #720 

## Testing Instructions

- Proceed through the user creation and sign on process, and verify that there are no errors in the console and that the help button shows up after you finish the initial setup process.

Closes #531