### PR TITLE
Bugfix action card view link goes to review step

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
@@ -44,7 +44,7 @@ export class ActionWizardComponent implements AfterViewInit, OnInit {
   @Input() action: Action;
 
   public namedRisk: NamedRisk;
-  startingStep = 0;
+  public startingStep = 0;
 
   constructor(private session: WizardSessionService<Action>,
               private actionService: ActionService,
@@ -60,14 +60,6 @@ export class ActionWizardComponent implements AfterViewInit, OnInit {
       const riskId: string = this.route.snapshot.paramMap.get('riskid');
       this.action.risk = riskId;
 
-      this.route.queryParams.take(1).subscribe((params: Params) => {
-        const indexes = {
-          'review': 5
-        };
-        // Default to the first step if the param doesn't match a valid step
-        this.startingStep = indexes[params['step']] || 0;
-      });
-
       if (this.route.snapshot.data['suggestedAction']) {
         const suggestion = this.route.snapshot.data['suggestedAction'] as Action;
         this.action.name = suggestion.name;
@@ -80,6 +72,16 @@ export class ActionWizardComponent implements AfterViewInit, OnInit {
         this.action.collaborators = suggestion.collaborators;
         this.action.categories = suggestion.categories;
       }
+    } else {
+      // Only allow jumping to other steps if we're not creating
+      //  a new action
+      this.route.queryParams.take(1).subscribe((params: Params) => {
+        const indexes = {
+          'review': 5
+        };
+        // Default to the first step if the param doesn't match a valid step
+        this.startingStep = indexes[params['step']] || 0;
+      });
     }
 
     this.riskService.get(this.action.risk).subscribe(risk => {


### PR DESCRIPTION
The "view" link on action step cards now properly routes to the review step of the action wizard.

### Demo

![mar-05-2018 10-30-20](https://user-images.githubusercontent.com/1818302/36983492-83166e6a-2060-11e8-8fa2-2bd445e0f05d.gif)

### Notes

I considered a more thorough refactor that updates both the Action and Risk wizard to pull their step params in the same way by matching against the `RiskStepKey` and `ActionStepKey` enums and using the same parameters in each, but this was a good extra chunk of work, and risks further regressions so I backed that work out. 

## Testing Instructions

Ensure you're still able to correctly perform the following interactions:
- Create new action from scratch
- Create new action from suggested action
- Edit existing action
- View existing action

I haven't worked in this area of the code for awhile, so some thorough testing would be warranted.

Closes #731 
