### PR TITLE
Disable risk card take action button if risk unassessed

### DIFF
--- a/src/angular/planit/src/app/action-steps/risk-card/risk-card.component.html
+++ b/src/angular/planit/src/app/action-steps/risk-card/risk-card.component.html
@@ -1,7 +1,11 @@
 <div class="risk-card">
   <div class="risk-card-content">
     <h3>{{ risk.weather_event.name }} on {{ risk.community_system.name }}</h3>
-    <button class="take-action button" (click)="openModal(actionPicker)">Take action</button>
+    <button class="take-action button"
+            tooltip="You need to assess this risk first"
+            [isDisabled]="risk.isAssessed()"
+            [ngClass]="{disabled: !risk.isAssessed()}"
+            (click)="openModal(actionPicker)">Take action</button>
   </div>
 </div>
 

--- a/src/angular/planit/src/app/action-steps/risk-card/risk-card.component.ts
+++ b/src/angular/planit/src/app/action-steps/risk-card/risk-card.component.ts
@@ -24,6 +24,8 @@ export class RiskCardComponent implements OnInit {
   ngOnInit() { }
 
   public openModal(template: TemplateRef<any>) {
-    this.modalRef = this.modalService.show(template, {animated: false, class: 'modal-lg'});
+    if (this.risk.isAssessed()) {
+      this.modalRef = this.modalService.show(template, {animated: false, class: 'modal-lg'});
+    }
   }
 }


### PR DESCRIPTION
### Demo

<img width="726" alt="screen shot 2018-03-05 at 11 02 23 am" src="https://user-images.githubusercontent.com/1818302/36985460-4e63be8e-2065-11e8-92bb-d1713c4ef925.png">

### Notes

Attempted to directly use `[disabled]="!risk.isAssessed()"`
but this disables events, requiring that the tooltip be on
a wrapper div. That wrapper div causes styling issues with
the current styles, so I reverted to using our custom
button.disabled class and cancelling the click in
the component.

## Testing Instructions

Ensure you can't open the action wizard for un-assessed risks. Ensure you can for assessed risks.

Closes #708 
