### PR TITLE
Scroll to top when entering next wizard step

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.html
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.html
@@ -22,6 +22,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="assessStep.save"
+                          (stepEnter)="resetScroll()"
                           navigationSymbol="{{ assessStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{'complete': assessStep.isStepComplete()}">1</span>
@@ -34,6 +35,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="implementationStep.save"
+                          (stepEnter)="resetScroll()"
                           stepTitle="{{ implementationStep.title }}"
                           navigationSymbol="{{ implementationStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
@@ -47,6 +49,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="improvementsStep.save"
+                          (stepEnter)="resetScroll()"
                           stepTitle="{{ improvementsStep.title }}"
                           navigationSymbol="{{ improvementsStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
@@ -60,6 +63,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="categoryStep.save"
+                          (stepEnter)="resetScroll()"
                           stepTitle="{{ categoryStep.title }}"
                           navigationSymbol="{{ categoryStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
@@ -73,6 +77,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="fundingStep.save"
+                          (stepEnter)="resetScroll()"
                           stepTitle="{{ fundingStep.title }}"
                           navigationSymbol="{{ fundingStep.navigationSymbol }}">
     <ng-template wizardStepTitle>

--- a/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
+++ b/src/angular/planit/src/app/action-wizard/action-wizard.component.ts
@@ -101,4 +101,7 @@ export class ActionWizardComponent implements AfterViewInit, OnInit {
       this.fundingStep.isStepComplete();
   }
 
+  public resetScroll() {
+    window.scrollTo(0, 0);
+  }
 }

--- a/src/angular/planit/src/app/create-plan/plan-wizard/plan-wizard.component.html
+++ b/src/angular/planit/src/app/create-plan/plan-wizard/plan-wizard.component.html
@@ -10,6 +10,7 @@
                             #dueDateStep
                             wizardStep
                             [canExit]="dueDateStep.save"
+                            (stepEnter)="resetScroll()"
                             stepTitle="{{ dueDateStep.title }}"
                             navigationSymbol="{{ dueDateStep.navigationSymbol }}">
     </app-plan-step-due-date>
@@ -19,6 +20,7 @@
                            wizardStep
                            optionalStep
                            [canExit]="hazardsStep.save"
+                           (stepEnter)="resetScroll()"
                            stepTitle="{{ hazardsStep.title }}"
                            navigationSymbol="{{ hazardsStep.navigationSymbol }}">
     </app-plan-step-hazards>
@@ -28,6 +30,7 @@
                                      wizardCompletionStep
                                      enableBackLinks
                                      (wizardCompleted)="onWizardCompleted($event)"
+                                     (stepEnter)="resetScroll()"
                                      stepTitle="{{ communitySystemsStep.title }}"
                                      navigationSymbol="{{ communitySystemsStep.navigationSymbol }}">
     </app-plan-step-community-systems>

--- a/src/angular/planit/src/app/create-plan/plan-wizard/plan-wizard.component.ts
+++ b/src/angular/planit/src/app/create-plan/plan-wizard/plan-wizard.component.ts
@@ -46,4 +46,8 @@ export class PlanWizardComponent implements OnInit {
       self.router.navigate(['dashboard']);
     }, 5000);
   }
+
+  public resetScroll() {
+    window.scrollTo(0, 0);
+  }
 }

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.html
@@ -18,6 +18,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="identifyStep.save"
+                          (stepEnter)="resetScroll()"
                           navigationSymbol="{{ identifyStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{'complete': identifyStep.isStepComplete()}">1</span>
@@ -30,6 +31,7 @@
                         wizardStep
                         optionalStep
                         [canExit]="hazardStep.save"
+                        (stepEnter)="resetScroll()"
                         navigationSymbol="{{ hazardStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{'complete': hazardStep.isStepComplete()}">2</span>
@@ -42,6 +44,7 @@
                         wizardStep
                         optionalStep
                         [canExit]="impactStep.save"
+                        (stepEnter)="resetScroll()"
                         navigationSymbol="{{ impactStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{'complete': impactStep.isStepComplete()}">3</span>
@@ -54,6 +57,7 @@
                           wizardStep
                           optionalStep
                           [canExit]="capacityStep.save"
+                          (stepEnter)="resetScroll()"
                           navigationSymbol="{{ capacityStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{'complete': capacityStep.isStepComplete()}">4</span>
@@ -65,6 +69,7 @@
                         #reviewStep
                         wizardCompletionStep
                         enableBackLinks
+                        (stepEnter)="resetScroll()"
                         navigationSymbol="{{ reviewStep.navigationSymbol }}">
     <ng-template wizardStepTitle>
       <span class="step-number" [ngClass]="{

--- a/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/risk-wizard.component.ts
@@ -58,4 +58,8 @@ export class RiskWizardComponent implements OnInit, AfterViewChecked {
       this.startingStep = params['goToStep'] || 0;
     });
   }
+
+  public resetScroll() {
+    window.scrollTo(0, 0);
+  }
 }


### PR DESCRIPTION
## Overview

When proceeding to the next step in a wizard (used when setting up a plan, selecting risks, and assigning actions), scroll to the top of the page. This ensures users see the complete form on each step, and that
the scroll position of the previous step has no effect on the next step.

### Demo

![mar-05-2018 13-21-08](https://user-images.githubusercontent.com/1042475/36992196-3499fc94-2078-11e8-904c-81ff825009d1.gif)

## Notes

I attempted to find a higher-level solution for this, but given the small footprint of the `resetScroll`, I didn't think it was worth the effort.

## Testing Instructions

- Create a new user, and proceed through the setup plan, risk, and action wizards. While moving through each step of each wizard, try scrolling to a particular position, and clicking continue. When the next step loads, the page should return to the top scrolling position.

Closes #726