### PR TITLE
Add visual identifier for active links

### DIFF
--- a/src/angular/planit/src/app/shared/footer/footer.component.html
+++ b/src/angular/planit/src/app/shared/footer/footer.component.html
@@ -2,10 +2,17 @@
   <nav class="footer-nav">
     <a routerLink="/" class="logo"><img src="assets/images/temperate-logo-full-left-neutral.svg" alt="Temperate, by Azavea"></a>
     <div class="nav-buttons">
-      <a class="button button-inverse-dark" routerLink="/methodology">Methodology</a>
-      <a class="button button-inverse-dark" routerLink="">Partnerships</a>
-      <a class="button button-inverse-dark" href="http://climate.azavea.com">Climate API</a>
-      <a *ngIf="router.url !== '/'" class="button button-inverse-dark" routerLink="/">About</a>
+      <a class="button button-inverse-dark"
+         routerLink="/methodology"
+         routerLinkActive="current">Methodology</a>
+      <a class="button button-inverse-dark"
+         routerLink="/"
+         routerLinkActive="current">Partnerships</a>
+      <a class="button button-inverse-dark" href="https://climate.azavea.com">Climate API</a>
+      <a class="button button-inverse-dark"
+         routerLink="/"
+         routerLinkActive="current"
+         [queryParams]="{ ref: 'footer' }">About</a>
     </div>
   </nav>
   <div class="fine-print">

--- a/src/angular/planit/src/app/shared/navbar/navbar.component.html
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.html
@@ -3,16 +3,17 @@
   <a *ngIf="router.url === '/'" routerLink="/" class="logo"><img src="assets/images/temperate-logo-white.svg" alt="Temperate, by Azavea"></a>
   <div class="nav-buttons" *ngIf="authService.isAuthenticated()">
     <a class="button button-inverse-light"
-       *ngIf="showLink('/dashboard')"
-       routerLink="/dashboard" >Dashboard</a>
+       routerLink="/dashboard"
+       routerLinkActive="current">Dashboard</a>
     <a class="button button-inverse-light"
-       *ngIf="showLink('/indicators')"
-       routerLink="/indicators">Indicators</a>
+       routerLink="/indicators"
+       routerLinkActive="current">Indicators</a>
     <app-user-dropdown></app-user-dropdown>
   </div>
   <nav class="nav-buttons" *ngIf="!authService.isAuthenticated()">
     <a class="button button-inverse-light"
-       routerLink="/pricing">Pricing</a>
+       routerLink="/pricing"
+       routerLinkActive="current">Pricing</a>
     <button class="button"
             routerLink="/login">Log In</button>
     <button class="button button-primary"

--- a/src/angular/planit/src/assets/sass/components/_button.scss
+++ b/src/angular/planit/src/assets/sass/components/_button.scss
@@ -23,6 +23,10 @@
     opacity: .5;
     cursor: not-allowed;
   }
+
+  &.current {
+    border-bottom: 2px solid $brand-black;
+  }
 }
 
 @mixin button-inverse-states($color) {
@@ -51,6 +55,10 @@
     border: 2px solid transparent;
     opacity: .5;
     cursor: not-allowed;
+  }
+
+  &.current {
+    border-bottom: 2px solid $color;
   }
 }
 


### PR DESCRIPTION
### Demo

![screen shot 2018-03-05 at 3 58 29 pm](https://user-images.githubusercontent.com/1818302/36999518-5d6c8586-208e-11e8-9ac2-c081aa9b3672.png)
![screen shot 2018-03-05 at 3 58 37 pm](https://user-images.githubusercontent.com/1818302/36999519-5ed7e802-208e-11e8-92c9-5fdc777c2e70.png)

### Notes

I think I got all the desired links, lmk if any functionality here doesn't match what's desired or I missed any spots.

Note that the Partnerships link just refers to `/` until #753 is merged, so it will show as active on all routes. For now, the first screenshot conveniently demonstrates both the normal and inverse button styles :)

#547 accidentally removed the `queryParams` input on the About button that properly routed logged in users back to the homepage. I reinstated that here.

I ignored the user dropdown as noted in the original issue.

@alexelash I just made something up for the `.current` styling. Feel free to request something different here, or submit a PR to this one to clean it up. If you'd rather address it later, that's fine too, I can make a separate issue once this is merged.

## Testing Instructions

Ensure the app now shows the desired state for each of the buttons in header + footer. 

Closes #713 
