### PR TITLE
Show city and state in city selection menu

### DIFF
--- a/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.html
+++ b/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.html
@@ -16,12 +16,15 @@
              typeaheadOptionField="properties.displayName"
              (typeaheadOnSelect)="itemSelected($event)"
              (typeaheadOnBlur)="itemBlurred()"
+             (typeaheadNoResults)="onNoResults()"
              (blur)="itemBlurred()"
+             (keyup)="onKey($event)"
              [typeahead]="cities"
              [typeaheadMinLength]="1"
              [typeaheadScrollable]="true"
              [typeaheadWaitMs]="100"
              [typeaheadOptionsInScrollableView]="5">
+      <div *ngIf="noResults" class="form-control-error">No results found</div>
       <div *ngIf="form.controls.location.errors">
         <span *ngIf="form.controls.location.errors.required">*Required</span>
         <span *ngIf="form.controls.location.errors.autocomplete">*Not found</span>

--- a/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.ts
+++ b/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.ts
@@ -29,6 +29,7 @@ export class CityStepComponent extends OrganizationWizardStepComponent<CityStepF
 
   public cities: Observable<ApiCity[]>;
   public city: ApiCity = null;
+  public noResults = false;
 
   @Input() form: FormGroup;
 
@@ -103,6 +104,7 @@ export class CityStepComponent extends OrganizationWizardStepComponent<CityStepF
 
     if (savedName !== formName) {
       this.city = event.item ? event.item : null;
+      this.noResults = false;
     }
   }
 
@@ -113,6 +115,17 @@ export class CityStepComponent extends OrganizationWizardStepComponent<CityStepF
     if (savedName !== formName) {
       this.form.controls.location.setValue('');
       this.city = null;
+      this.noResults = false;
+    }
+  }
+
+  onNoResults() {
+    this.noResults = true;
+  }
+
+  onKey(e) {
+    if (e.target.value === '') {
+      this.noResults = false;
     }
   }
 


### PR DESCRIPTION
## Overview

Helps disambiguate cities in different states with the same name. Also, the admin (state) field was being searched, which lead to confusing results because the state value was not displayed anywhere.

### Demo

![image](https://user-images.githubusercontent.com/1042475/37033994-d5ba7084-2115-11e8-8abf-d02188a37da6.png)


### Notes

I wasn't able to update the value displayed after making a selection from the list. It currently just shows the city name. Allegedly, the `typeaheadOptionField`, which is used for the selected value, can take a function which returns a value to display. I couldn't find any examples of how to do this, and all of my implementation approaches failed.

## Testing Instructions

- Create a new user.
- On the first step of the "Setup a plan" wizard, try typing different letters in the city menu.
- Verify that all results contain a state.

Closes #762
Closes #767 