### PR TITLE
Add DoCheck to list of implemented component interfaces

### DIFF
--- a/src/angular/planit/src/app/shared/indicator-chart/indicator-chart.component.ts
+++ b/src/angular/planit/src/app/shared/indicator-chart/indicator-chart.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DoCheck,
   ElementRef,
   EventEmitter,
   Input,
@@ -41,7 +42,7 @@ import {
   selector: 'app-indicator-chart',
   templateUrl: './indicator-chart.component.html'
 })
-export class IndicatorChartComponent implements OnInit {
+export class IndicatorChartComponent implements OnInit, DoCheck {
   @Input() indicator: Indicator;
   @Input() city: City;
 


### PR DESCRIPTION
Fixes up a linter error accidentally introduced in #757

Trivial, merging, `./scripts/test` passes locally.