### PR TITLE
Make the action category step optional

### DIFF
--- a/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.html
@@ -31,6 +31,6 @@
           (click)="finish()">Finish later</button>
   <div class="step-footer-navigation">
     <button type="button" tabindex="2" nextStep>Skip Step</button>
-    <button type="button" tabindex="3" [disabled]="!haveSelectedActionCategory()" nextStep>Continue</button>
+    <button type="button" tabindex="3" nextStep>Continue</button>
   </div>
 </div>

--- a/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
@@ -47,13 +47,6 @@ export class CategoryStepComponent extends ActionWizardStepComponent<ActionCateg
     });
   }
 
-  // check if any of the action categories have been selected
-  public haveSelectedActionCategory(): boolean {
-    return this.actionCategories && !!this.actionCategories.find(function(cat: ActionCategory) {
-      return cat.selected;
-    });
-  }
-
   // toggle button selections on click
   public selectActionCategory(actionCategory: ActionCategory) {
     actionCategory.selected = !actionCategory.selected;


### PR DESCRIPTION
## Overview

This step was marked as optional, but the continue button being active was contingent on wether or not a category has been selected. That requirement has been removed.

## Testing Instructions

- Visit the action wizard.
- Proceed through the steps, and verify that the continue button is not disabled on the category step before selecting any categories.

Closes #777 