### PR TITLE
Don't show form errors until form has been edited

### DIFF
--- a/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.html
@@ -22,7 +22,7 @@
                 rows="4"
                 tabindex="1"
                 required></textarea>
-      <div *ngIf="form.controls.name.errors">
+      <div *ngIf="form.controls.name.errors && (form.controls.name.dirty || form.controls.name.touched)">
         <span *ngIf="form.controls.name.errors.required">*Required</span>
       </div>
     </div>

--- a/src/angular/planit/src/app/create-plan/plan-wizard/steps/due-date-step/due-date-step.component.html
+++ b/src/angular/planit/src/app/create-plan/plan-wizard/steps/due-date-step/due-date-step.component.html
@@ -22,7 +22,7 @@
                [minDate]="minDate"
                [bsConfig]="{ containerClass: 'theme-default' }"
                tabindex="1">
-        <div *ngIf="form.controls.plan_due_date.errors">
+        <div *ngIf="form.controls.plan_due_date.errors && (form.controls.plan_due_date.dirty || form.controls.plan_due_date.touched)">
           <span *ngIf="form.controls.plan_due_date.errors.required">*Required</span>
           <div *ngIf="form.controls.plan_due_date.errors.bsDate">
             <span *ngIf="form.controls.plan_due_date.errors.bsDate.invalid &&

--- a/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.html
+++ b/src/angular/planit/src/app/organization-wizard/steps/city-step/city-step.component.html
@@ -25,7 +25,7 @@
              [typeaheadWaitMs]="100"
              [typeaheadOptionsInScrollableView]="5">
       <div *ngIf="noResults" class="form-control-error">No results found</div>
-      <div *ngIf="form.controls.location.errors">
+      <div *ngIf="form.controls.location.errors && (form.controls.location.dirty || form.controls.location.touched)">
         <span *ngIf="form.controls.location.errors.required">*Required</span>
         <span *ngIf="form.controls.location.errors.autocomplete">*Not found</span>
         <span *ngIf="form.controls.location.errors.server">
@@ -41,7 +41,7 @@
              formControlName="name"
              type="text"
              tabindex="2">
-      <div *ngIf="form.controls.name.errors">
+      <div *ngIf="form.controls.name.errors && (form.controls.name.dirty || form.controls.name.touched)">
         <span *ngIf="form.controls.name.errors.required">*Required</span>
         <span *ngIf="form.controls.name.errors.server">
           *{{ form.controls.name.errors.server }}

--- a/src/angular/planit/src/app/risk-wizard/steps/identify-step/identify-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/identify-step/identify-step.component.html
@@ -17,7 +17,7 @@
                                   [typeaheadScrollable]="true"
                                   [typeaheadOptionsInScrollableView]="5"
                                   [container]="'body'">
-      <div *ngIf="form.controls.weather_event.errors">
+      <div *ngIf="form.controls.weather_event.errors && (form.controls.weather_event.dirty || form.controls.weather_event.touched)">
         <span *ngIf="form.controls.weather_event.errors.required">*Required</span>
         <span *ngIf="form.controls.weather_event.errors.autocomplete">*Not found</span>
       </div>
@@ -36,7 +36,7 @@
                                   [typeaheadScrollable]="true"
                                   [typeaheadOptionsInScrollableView]="5"
                                   [container]="'body'">
-      <div *ngIf="form.controls.community_system.errors">
+      <div *ngIf="form.controls.community_system.errors && (form.controls.community_system.dirty || form.controls.community_system.touched)">
         <span *ngIf="form.controls.community_system.errors.required">*Required</span>
         <span *ngIf="form.controls.community_system.errors.autocomplete">*Not found</span>
       </div>


### PR DESCRIPTION
## Overview

Prevents the errors from showing up when the form is loaded.

Based on this note in the documentation:
https://angular.io/guide/form-validation#why-check-dirty-and-touched

## Testing Instructions

- Create a new user, and proceed through the plan setup, risk, and action wizards. Ensure that no form errors (the most common being `* Required`) show up until you edit a field.

Closes #776