### PR TITLE
Remove city profile section from dashboard

### DIFF
--- a/src/angular/planit/src/app/dashboard/dashboard.component.html
+++ b/src/angular/planit/src/app/dashboard/dashboard.component.html
@@ -28,7 +28,6 @@
                 (click)="openModal(weatherEventsModal)">Add Hazard</button>
       </div>
       <div class="dashboard-sidebar">
-        <app-city-profile-summary></app-city-profile-summary>
         <div class="plan-review">Review</div>
         <a (click)="downloadPlan()">Download plan (CSV)</a>
       </div>


### PR DESCRIPTION
## Overview

This feature will not be ready for launch.

### Demo

![image](https://user-images.githubusercontent.com/1042475/37110466-01596790-220b-11e8-86f9-985f60369bb6.png)

## Testing Instructions

- Visit the dashboard and ensure the user profile section is removed.

Closes #648