### PR TITLE
Do not show 0 days remaining for trials

### DIFF
--- a/src/angular/planit/src/app/shared/models/organization.model.ts
+++ b/src/angular/planit/src/app/shared/models/organization.model.ts
@@ -59,7 +59,7 @@ export class Organization {
 
   public trialDaysRemaining() {
     const oneDayMillis = 1000 * 60 * 60 * 24;
-    const daysRemaining = Math.ceil(this.trialMillisRemaining() / oneDayMillis);
+    const daysRemaining = Math.floor(this.trialMillisRemaining() / oneDayMillis);
     return Math.max(daysRemaining, 1);
   }
 


### PR DESCRIPTION
## Overview
Puts a minimum threshold for remaining days in a trial to 1 to avoid showing a "You have 0 days remaining" message - in theory, the trial should have ended when it reached 0.

This opens a slightly wonky scenario where the trial has long ended but the user is still told their trial has another day, but that should be handled by #602 or other issue.

### Demo
<img width="816" alt="screen shot 2018-03-07 at 3 29 46 pm" src="https://user-images.githubusercontent.com/1032849/37116458-645a2436-221c-11e8-992b-d8c71a072364.png">

### Notes
This splits the "Has support?" and "Days remaining" methods for organizations, so that once an organizations trial ends they lose the support button.

## Testing Instructions
- In the admin panel, set your organization subscription type to trial and subscription end date to a point in the past
  - In the Angular app, you should see a modal that says "You have 1 more day...", but no help icon
- Repeat with your subscription end date set to _tomorrow_
  - You should receive same modal message, but see a help icon at the bottom of the page

Closes #790 
