### PR TITLE
Adjust current page indicator style

### DIFF
--- a/src/angular/planit/src/assets/sass/components/_button.scss
+++ b/src/angular/planit/src/assets/sass/components/_button.scss
@@ -56,7 +56,7 @@
     border: 2px solid rgba($color, 0.2);
     background-color: rgba($color, 0.1);
     color: $color;
-  } 
+  }
 
   &:disabled, &.disabled {
     border: 2px solid transparent;
@@ -65,7 +65,19 @@
   }
 
   &.current {
-    border-bottom: 2px solid $color;
+    position: relative;
+    border-bottom-color: transparent;
+
+    &::before {
+      content: '';
+      position: absolute;
+      height: 2px;
+      width: calc(100% - #{2 * $button-padding-horizontal});
+      left: $button-padding-horizontal;
+      right: $button-padding-horizontal;
+      bottom: 0.2rem;
+      background-color: $color;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

Tweak the underline treatment of the current page indicator.

### Demo

#### Before
<img width="336" alt="screen shot 2018-03-08 at 10 20 27 am" src="https://user-images.githubusercontent.com/128699/37160718-df1c974c-22be-11e8-988c-f9d19df77bcc.png">

#### After
<img width="338" alt="screen shot 2018-03-08 at 10 52 37 am" src="https://user-images.githubusercontent.com/128699/37160719-df3137d8-22be-11e8-8605-54972fa78f03.png">

#### Footer
![image](https://user-images.githubusercontent.com/128699/37161192-06169b8a-22c0-11e8-8879-a3ce17c3ded3.png)


## Testing Instructions

 * `pull` and `server`
 * Go to the Dashboard, Indicators, or Methodology page
 * Take a look at the current page indicator