### PR TITLE
Support adding items via enter key for multi-select 

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
@@ -1,5 +1,6 @@
 <div class="input-group" *ngIf="!isDisabled">
   <input class="form-control" placeholder="Type to search. Add new item by clicking the +"
+         (keyup.enter)="add()"
          [attr.id]="inputId"
          autocomplete="off"
          [(ngModel)]="selected"

--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
@@ -1,3 +1,5 @@
+import * as some from 'lodash.some';
+
 import { Component, Input, OnChanges, SimpleChanges, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -35,9 +37,17 @@ export class FreeformMultiselectComponent implements ControlValueAccessor, OnCha
 
   public add() {
     const selected = this.selected.trim();
+
     if (!selected) {
       return;
     }
+
+    // Don't add text that partially matches an item in the options list
+    if (some(Array.from(this.availableOptions),
+        (opt) => opt.toLowerCase().search(selected.toLowerCase()) !== -1 && selected !== opt )) {
+      return;
+    }
+
     this.selectedOptions.add(selected);
     this.availableOptions.delete(this.selected);
     this.onChange(Array.from(this.selectedOptions));


### PR DESCRIPTION
## Overview

Phrases that were not found in the autosuggestions for freeform multi-selects could only be added by clicking the '+' button. Now, users can press the enter button to add them to their list of values.

## Testing Instructions

- On the "Adaptive capacity" step of the risk wizard and the  "Outcomes" step of the action wizard, try typing a phrase that doesn't appear in the auto-suggestion menu. Pressing enter should add the phrase to the selected items.

Closes #721