### PR TITLE
remove `app.` from URL

### DIFF
--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -7,7 +7,7 @@ data "aws_route53_zone" "external" {
 
 resource "aws_route53_record" "planit_app" {
   zone_id = "${data.aws_route53_zone.external.zone_id}"
-  name    = "app.${data.aws_route53_zone.external.name}"
+  name    = "${data.aws_route53_zone.external.name}"
   type    = "A"
 
   alias {

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -4,13 +4,13 @@ upstream django-upstream {
 
 server {
 	listen 80 default_server;
-	server_name app.temperate.io app.staging.temperate.io;
+	server_name temperate.io staging.temperate.io;
 	return 301 https://$host/$request_uri;
 }
 
 server {
 	listen 443 default_server;
-	server_name app.temperate.io app.staging.temperate.io localhost;
+	server_name temperate.io staging.temperate.io localhost;
 
 	include /etc/nginx/includes/security-headers.conf;
 


### PR DESCRIPTION
## Overview

Change project URL from `app.temperate.io` to `temperate.io`.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

This change is live in Staging. see https://staging.temperate.io


## Testing Instructions

- See https://staging.temperate.io

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with appropriate notes for this PR?

Closes #732 
