### PR TITLE
Clarify intent of PR template changelog reminder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case, and expected output
 
- - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with appropriate notes for this PR?
+ - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.
 
 Closes #XXX


### PR DESCRIPTION
We want to ensure we note changes that would require
special consideration on our next deployment, but
aren't yet concerned with documenting all changes to user facing features.

Example changes that might trigger adding a comment:
- Added a new terraform variable
- Modified some related data and have to run an
  import script

