### PR TITLE
Harmonize behavior of multiselect save events

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
@@ -1,17 +1,17 @@
 <div class="input-group" *ngIf="!isDisabled">
   <input class="form-control" placeholder="Type to search. Add new item by clicking the +"
-         (keyup.enter)="add()"
+         (keyup.enter)="onEnter()"
          [attr.id]="inputId"
          autocomplete="off"
          [(ngModel)]="selected"
-         (typeaheadOnSelect)="add()"
+         (typeaheadOnSelect)="onSelect($event)"
          [typeahead]="availableOptions"
          [typeaheadMinLength]="1"
          [typeaheadScrollable]="true"
          [typeaheadOptionsInScrollableView]="5"
          [typeaheadOptionsLimit]="100"
          [container]="'body'">
-  <button class="button button-icon" type="button" (click)="add()"><i class="icon-plus"></i></button>
+  <button class="button button-icon" type="button" (click)="onAdd()"><i class="icon-plus"></i></button>
 </div>
 <div class="input-group" *ngIf="isDisabled">
   <input class="form-control" placeholder="Type to search. Add new item by clicking the +" disabled [attr.id]="inputId">

--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
@@ -35,16 +35,29 @@ export class FreeformMultiselectComponent implements ControlValueAccessor, OnCha
     }
   }
 
-  public add() {
+  // From the add button, get the value from the model.
+  public onAdd() {
     const selected = this.selected.trim();
+    this.add(selected);
+  }
 
+  // From the enter key, also get the value from the model, but wait a moment in case this
+  // "enter" press triggered a selection, since we then want the onSelect to take precedence
+  // and clear the input.
+  public onEnter() {
+    setTimeout(() => {
+      this.onAdd(); }
+    , 100);
+  }
+
+  // From a typeahead selection, use the event value
+  public onSelect(event: TypeaheadMatch) {
+    this.add(event.item);
+  }
+
+  // Shared logic to store a value, remove it from available options, and clear the input.
+  private add(selected: string) {
     if (!selected) {
-      return;
-    }
-
-    // Don't add text that partially matches an item in the options list
-    if (some(Array.from(this.availableOptions),
-        (opt) => opt.toLowerCase().search(selected.toLowerCase()) !== -1 && selected !== opt )) {
       return;
     }
 


### PR DESCRIPTION
In looking at the multiselect field for #771, I noticed that the change in #817 has the unfortunate side-effect that it ignores any free-form value that's a substring of an available option.  So for instance if I want to enter just "Education" as an adaptive value, not the suggested "Access to Education", even if I click the "+" button or click out of the field to close the suggestions then press enter, it just ignores me.

Seems like there are a number of actions that cause the multiselect field to save:
- Selecting from the list (with mouse, enter key, or tab key*), which should save the selected value from the list.
- Hitting "Enter" with no suggestions showing, which should save exactly what's entered in the field.
- The plus button, which should save exactly what's in the field even if there are suggestions showing.

(* We might not actually want the tab key to select, but I'm leaving that aside for the moment.)

The bad interaction that the substring search is working around is between the first two--since hitting "enter" when there are suggestions showing triggers both the "keyup.enter" event and the typeahead selection event.

This PR breaks out some of the behavior of the `add` method to enable different treatment for the different entry methods.  Most notably, it lets us put a timeout on the enter key event so that if the select event is also firing, it can go first and clear the input to avoid saving the raw input value in addition to the suggested item.

I'm putting this up as a PR by itself because I expect #771 will also require some changes to how this widget does its saving, and it seems better to avoid mixing that with this.

### Demo

![image](https://user-images.githubusercontent.com/6598836/37225606-26906aa4-23a5-11e8-8163-163b5aaa23ef.png)

## Testing Instructions

On the "Adaptive capacity" step of the risk wizard and the "Outcomes" step of the action wizard...
- Type a phrase that doesn't match a suggested value and pressing enter.  The entered value should show up in the list below the input.
- Type a phrase that matches part of a suggested value and press enter.  The first suggested value should show up in the list.
- Type a phrase that matches part of a suggested value and press "+".  The phrase you typed, not the first suggested value, should show up in the list.

Connects #721.