### PR TITLE
Move /add-city to /api/add-city

### DIFF
--- a/src/angular/planit/src/app/core/services/add-city.service.ts
+++ b/src/angular/planit/src/app/core/services/add-city.service.ts
@@ -23,7 +23,7 @@ export class AddCityService {
     });
     const headers = new Headers({ 'Content-Type': 'application/json' });
     const options = new RequestOptions({ headers: headers });
-    const url = `${environment.apiUrl}/add_city/`;
+    const url = `${environment.apiUrl}/api/add_city/`;
     return this.apiHttp.post(url, body, options);
   }
 }

--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -58,9 +58,9 @@ urlpatterns = [
 
     # user management
     url(r'^accounts/', include('users.urls')),
+    url(r'^api/add_city/', AddCityView.as_view(), name='add_city'),
     url(r'^api/user/$', CurrentUserView.as_view(), name='current_user'),
     url(r'^api-token-auth/', PlanitObtainAuthToken.as_view(), name='token_auth'),
-    url(r'^add_city/', AddCityView.as_view(), name='add_city'),
 
     # Health check
     url(r'^health-check/', include('watchman.urls')),


### PR DESCRIPTION
### Demo

![screen shot 2018-03-09 at 4 15 40 pm](https://user-images.githubusercontent.com/1818302/37230335-2cbfb1cc-23b5-11e8-8411-f5476819fbe2.png)


![screen shot 2018-03-09 at 4 09 28 pm](https://user-images.githubusercontent.com/1818302/37230235-b2f203b8-23b4-11e8-927f-0a58d30b9ea0.png)


### Notes

I moved the route under `/api` because it's part of the API enough for that to make more sense IMO then adding another nginx route exception for the Django app. Keeps the nginx list manageable.

## Testing Instructions

- Ensure the add-city workflow still works in dev, via `./scripts/server`
- Stop the dev server, and start the nginx test server with `./scripts/server --nginx`. Navigate to localhost:8000 and test the same add-city workflow. The email should print to the django docker console same as before.


Closes #821 
