### PR TITLE
Display loader on suggested actions modal

### DIFF
--- a/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.html
+++ b/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.html
@@ -1,5 +1,5 @@
 <!-- "How do you want to start?" prompt -->
-<div class="action-picker" *ngIf="showPrompt && suggestedActions.length > 0">
+<div class="action-picker" *ngIf="showPrompt && (loading || suggestedActions.length > 0)">
   <header class="modal-header">
     <h1 class="modal-title">Take action</h1>
     <button type="button"
@@ -9,13 +9,18 @@
     </button>
   </header>
   <div class="modal-body">
-    <div class="suggested-actions-cta">
+    <div class="display-flex flex-vertical" *ngIf="loading">
+      <div class="loading-wrapper">
+        <div class="loading loading-spinner loading-large loading-primary"></div>
+      </div>
+    </div>
+    <div class="suggested-actions-cta" *ngIf="!loading">
       <div class="suggested-actions-overview">
         <div class="recommended">Recommended</div>
         <h2 class="title">Begin with suggested actions</h2>
         <p class="description">We&apos;ve gathered actions that some cities have undertaken over the years and will recommend some for you to start with.</p>
       </div>
-      <button class="button button-positive suggested-actions-button" (click)="showPrompt = false">
+      <button *ngIf="!loading" class="button button-positive suggested-actions-button" (click)="showPrompt = false">
         Get started
       </button>
     </div>
@@ -26,7 +31,7 @@
 </div>
 
 <!-- Alternate prompt when no actions were found -->
-<div class="action-picker" *ngIf="showPrompt && suggestedActions.length === 0">
+<div class="action-picker" *ngIf="!loading && showPrompt && suggestedActions.length === 0">
   <header class="modal-header">
     <h1 class="modal-title">Develop a custom action step</h1>
     <button type="button"
@@ -56,7 +61,7 @@
       <i class="icon-cancel"></i>
     </button>
   </div>
-  <div class="modal-body">
+  <div class="modal-body" *ngIf="!loading">
     <p class="suggested-actions-description">Actions below were chosen for you based on your region and the selected hazard and/or community system.</p>
     <div class="suggested-action" *ngFor="let suggestion of suggestedActions">
       <div class="action-main">

--- a/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.ts
+++ b/src/angular/planit/src/app/action-steps/action-picker/action-picker.component.ts
@@ -17,6 +17,7 @@ export class ActionPickerComponent implements OnInit {
 
   @Output() closed: EventEmitter<string> = new EventEmitter();
 
+  public loading = true;
   public showPrompt = true;
 
   constructor(private location: Location,
@@ -28,7 +29,10 @@ export class ActionPickerComponent implements OnInit {
   suggestedActions: SuggestedAction[] = [];
 
   ngOnInit() {
-    this.suggestedActionService.list(this.risk).subscribe(s => this.suggestedActions = s);
+    this.suggestedActionService.list(this.risk).subscribe(s => {
+      this.suggestedActions = s;
+      this.loading = false;
+    });
   }
 
   closeModal() {


### PR DESCRIPTION
## Overview

While waiting to retrieve suggested actions, show a loader on the modal.


### Demo

![suggested_actions_loader](https://user-images.githubusercontent.com/960264/37291404-f4933472-25e4-11e8-9f52-9b3db0ef9b05.png)


### Notes

To test, load Missy's data set. "Drought on fisheries" has suggestions for the Northeast region.


## Testing Instructions

 * Click 'take action' from the `/actions` page to open the modal
 * Until suggested actions are retrieved, loader should show
 * Loader should hide and display appropriate text if there are suggested actions
 * Loader should hide and display appropriate text if there are *no* suggested actions

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #707
