### PR TITLE
Fixup client side choice string for OrgRisk.Directional.UNSURE

### DIFF
--- a/src/angular/planit/src/app/shared/models/org-risk-directional-option.model.ts
+++ b/src/angular/planit/src/app/shared/models/org-risk-directional-option.model.ts
@@ -1,6 +1,9 @@
+// The strings in this enum are equivalent to the available options in our API,
+//  defined at planit_data.models.OrganizationRisk.Directional
+// These strings should only be changed if the options in that class are changed.
 export enum OrgRiskDirectionalOption {
   Decreasing = 'decreasing',
   NoChange = 'no change',
   Increasing = 'increasing',
-  NotSure= 'not sure'
+  NotSure= 'unsure'
 }

--- a/src/angular/planit/src/app/shared/models/org-risk-relative-option.model.ts
+++ b/src/angular/planit/src/app/shared/models/org-risk-relative-option.model.ts
@@ -1,3 +1,6 @@
+// The strings in this enum are equivalent to the available options in our API,
+//  defined at planit_data.models.OrganizationRisk.Relative
+// These strings should only be changed if the options in that class are changed.
 // The adaptive need tooltip box expects these to be declared in ascending severity
 export enum OrgRiskRelativeOption {
   Unsure = 'unsure',


### PR DESCRIPTION
### Demo

![mar-12-2018 11-31-38](https://user-images.githubusercontent.com/1818302/37293357-672ec740-25e9-11e8-9f56-dc68e595cd2f.gif)

### Notes

Added a comment to both Angular enum declarations for
Directional and Relative to better link the two to
their Django definitions

## Testing Instructions

Assess a risk. Ensure that selecting the "Not Sure" button for both items on the "Hazard" step does not throw a generic error.

Closes #837 
