### PR TITLE
Keep unsaved multi-select values

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
@@ -5,6 +5,7 @@
          autocomplete="off"
          [(ngModel)]="selected"
          (typeaheadOnSelect)="onSelect($event)"
+         (change)="onUnsavedChange()"
          [typeahead]="availableOptions"
          [typeaheadMinLength]="1"
          [typeaheadScrollable]="true"
@@ -18,11 +19,13 @@
   <button class="button button-icon" type="button" disabled><i class="icon-plus"></i></button>
 </div>
 <div>
-  <div *ngFor="let option of selectedOptions" class="selected-option">
-    {{ option }}
-    <button type="button" class="button button-icon-only" aria-label="Close"
-            (click)="remove(option)" title="Remove">
-      <i class="icon-cancel"></i>
-    </button>
-  </div>
+  <ng-template ngFor let-option [ngForOf]="selectedOptions">
+    <div *ngIf="option !== unsaved" class="selected-option">
+      {{ option }}
+      <button type="button" class="button button-icon-only" aria-label="Close"
+              (click)="remove(option)" title="Remove">
+        <i class="icon-cancel"></i>
+      </button>
+    </div>
+  </ng-template>
 </div>


### PR DESCRIPTION
## Overview

The freeform multiselect field currently requires that a value be selected from the list or saved with the enter key or plus button to be actually saved. This makes a certain amount of sense, but makes it different from most other fields where typing an answer is sufficient, and it makes it easy to accidentally lose entries.  This changes it to track all changes and add values as soon as they're typed.  To preserve the interaction, the 'unsaved' value is hidden from the list of entered values while the user is on the page, but it's there in the summary and won't be lost when they leave the wizard.

Leaving the step and coming back without leaving the wizard has no visible effect, but leaving the wizard altogether and coming back results in the unsaved value being converted to a normal saved value and being shown in the list below the input.

This approach resulted from
- The discussion on issue #771 which concluded that we should assume that if the user typed something, they want to keep it, and that it would be annoying to turn this into a validation error (i.e. we shouldn't yell at them to take extra steps when their intentions are already clear).
- @maurizi solving the problem of how to represent the middle ground between entered and saved by treating the input as a list member that behaves differently.

### Demo

![image](https://user-images.githubusercontent.com/6598836/37294855-23342270-25ed-11e8-9eb8-27c2c8d1f655.png)

![image](https://user-images.githubusercontent.com/6598836/37294859-268ff41c-25ed-11e8-9186-c98fcb80a16d.png)

### Notes

- I tried it with both `(change)` and `(ngModelChange)`.  The former passes an event and only fires when the input loses focus.  The latter passes the raw value and fires on every change (e.g. every letter typed).  I went with `(change)` because I think it's sufficient.  Firing more often wouldn't hurt, but I don't think it would help anything.

## Testing Instructions

- Go to a view with a freeform multi-select interface ("Assess > Adaptive capacity" or "Take Action > Outcomes")
- Type something in the field and click away:
   - After moving to a different step and returning, the typed value should still be in the field
   - On the Review step, the text in the field should show up an item in the "Related adaptive values:" or "Departments to collaborate with:" list.
- Leave the wizard and come back. The item that was in the field should now show up in the lists as though it had been explicitly saved.

Resolves #771.