### PR TITLE
Replace lorempixel images with fontello icons

### DIFF
--- a/src/angular/planit/src/app/marketing/marketing.component.html
+++ b/src/angular/planit/src/app/marketing/marketing.component.html
@@ -22,21 +22,21 @@
     <div class="illustration-fullwidth">
       <div class="illustration-row">
         <figure id="figure-1" class="illustration figure-third">
-          <img src="https://lorempixel.com/201/200/" alt="" />
+          <span class="icon icon-indicators-1"></span>
           <figcaption>Access dependable projection data</figcaption>
         </figure>
         <figure id="figure-2" class="illustration figure-third">
-          <img src="https://lorempixel.com/203/200/" alt="" />
+          <span class="icon icon-advocacy"></span>
           <figcaption>Collaborate with your team</figcaption>
         </figure>
         <figure id="figure-3" class="illustration figure-third">
-          <img src="https://lorempixel.com/200/200/" alt="" />
+          <span class="icon icon-edit"></span>
           <figcaption>Create and export an assessment</figcaption>
         </figure>
       </div>
       <div class="illustration-row">
         <figure id="figure-4" class="illustration figure-full">
-          <img src="https://lorempixel.com/202/200/" alt="" />
+          <span class="icon icon-plus"></span>
           <figcaption>receive support from ICLEI every step of the way</figcaption>
         </figure>
       </div>


### PR DESCRIPTION
## Overview

The lorempixel images aren't so great sometimes. Since we'll be opening temperate to the world, this PR replaces those images with some semi-sensible icons from our fontello pack.

### Demo

![screen shot 2018-03-12 at 3 11 51 pm](https://user-images.githubusercontent.com/1818302/37304512-297c96b0-2608-11e8-96a0-d59dca450cd0.png)

### Notes

This was already approved by @alexelash, merging immediately.
