### PR TITLE
Hide dashboard and indicator links for new users

### DIFF
--- a/src/angular/planit/src/app/shared/navbar/navbar.component.html
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.html
@@ -3,9 +3,11 @@
   <a *ngIf="router.url === '/'" routerLink="/" class="logo"><img src="assets/images/temperate-logo-white.svg" alt="Temperate, by Azavea"></a>
   <div class="nav-buttons" *ngIf="authService.isAuthenticated()">
     <a class="button button-inverse-light"
+       *ngIf="showLink()"
        routerLink="/dashboard"
        routerLinkActive="current">Dashboard</a>
     <a class="button button-inverse-light"
+       *ngIf="showLink()"
        routerLink="/indicators"
        routerLinkActive="current">Indicators</a>
     <app-user-dropdown></app-user-dropdown>

--- a/src/angular/planit/src/app/shared/navbar/navbar.component.ts
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.ts
@@ -40,9 +40,14 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.userSubscription.unsubscribe();
   }
 
-  private showLink(link: string): boolean {
-    const url = this.router.url;
-    return link !== url && '/create-organization' !== url && '/plan' !== url;
+  private showLink(): boolean {
+    if (this.user && this.user.primary_organization) {
+      if (this.user.primary_organization.plan_setup_complete) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private getCurrentUser() {


### PR DESCRIPTION
## Overview

While the user is selecting their organization and setting up their plan, hide the links to the dashboard and indicator pages. These pages are not relevant until the user has finished setting up their plan.

These links were previously hidden until the active link indicator was added. Since they should no longer be hidden when the given page is active, the link parameter is no longer required and the links are only hidden when the user is setting up their plan.

## Testing Instructions

- Create a new user, and proceed through selecting your organization and setting up a plan. The dashboard and indicator links should not be displayed.
- Finish setting up your plan. The links should appear when you are forwarded to the dashboard.

Closes #822
