### PR TITLE
Style disabled buttons and remove hover

### DIFF
--- a/src/angular/planit/src/assets/sass/components/_button.scss
+++ b/src/angular/planit/src/assets/sass/components/_button.scss
@@ -189,7 +189,16 @@
 }
 
 .button-icon {
-    padding: $button-padding-vertical;
+  padding: $button-padding-vertical;
+
+  &.button-small {
+    padding: $button-padding-vertical-small;
+  }
+
+  &.button-large {
+    font-size: $text-base;
+    padding: $button-padding-vertical-large;
+  }
 }
 
 .button-floating {


### PR DESCRIPTION
## Overview
This PR changes the style of our disabled buttons to a low-opacity, gray state. It also removes a visual bug we've had for a while of visible hover states. 

### Demo
<img width="870" alt="screen shot 2018-03-14 at 1 46 07 pm" src="https://user-images.githubusercontent.com/5672295/37421470-c780aed6-278f-11e8-9ee9-c1883707ccd5.png">
<img width="870" alt="screen shot 2018-03-14 at 1 46 18 pm" src="https://user-images.githubusercontent.com/5672295/37421472-c7910286-278f-11e8-9d6b-162ee4b7422f.png">

### Notes
- A user can still `:focus` on any element that is just using `.disabled` (e.g. `<a>` tags). More would need to be done to make something _actually_ disabled (such as `tabindex=-1`). To this end, I didn't block out styles created by the visible `:focus` state.

Closes #759
