### PR TITLE
Remove all register links on production

### DIFF
--- a/src/angular/planit/src/app/login-page/login-page.component.html
+++ b/src/angular/planit/src/app/login-page/login-page.component.html
@@ -12,7 +12,7 @@
       </div>
       <div *ngIf="activationFailed" class="alert alert-warning">
         <p>Account activation failed.</p>
-        You may not have copied the entire URL into your web browser, or the activation link may have expired. Please try again, or <a routerLink="/register">register for an account</a>.
+        You may not have copied the entire URL into your web browser, or the activation link may have expired. Please try again<span *ngIf="hostname !== 'temperate.io'">, or <a routerLink="/register">register for an account</a></span>.
       </div>
       <div *ngIf="reset" class="alert alert-positive">
         Your Temperate password was reset. Log in to get started.

--- a/src/angular/planit/src/app/login-page/login-page.component.ts
+++ b/src/angular/planit/src/app/login-page/login-page.component.ts
@@ -13,6 +13,8 @@ export class LoginPageComponent implements OnInit {
   public reset = false;
   public resetExpired = false;
 
+  public hostname = window.location.hostname;
+
   constructor(private activatedRoute: ActivatedRoute,
               private router: Router) {}
 

--- a/src/angular/planit/src/app/marketing/marketing.component.html
+++ b/src/angular/planit/src/app/marketing/marketing.component.html
@@ -4,6 +4,7 @@
       <h1 class="heading text-jumbo">Your companion for planning a brighter future</h1>
       <p>Temperate guides you through creating a climate adaptation plan for your city from start to finish.</p>
       <button class="contact-iclei button button-primary button-large"
+              *ngIf="hostname !== 'temperate.io'"
               routerLink="/register">Create an Account</button>
     </div>
     <div class="helper-arrow">What is this?</div>
@@ -47,6 +48,7 @@
       <h2 class="heading">Get expert guidance</h2>
       <p class="paragraph-intro">As a registered member, you’ll have on-demand access to a adaptation planner at ICLEI. With more than 25 years of experience helping local governments adopt sustainable practices, ICLEI staff will assist you in building your adaptation plan.</p>
       <button class="contact-iclei button button-primary button-large"
+              *ngIf="hostname !== 'temperate.io'"
               routerLink="/register">Create an account</button>
     </div>
   </section>

--- a/src/angular/planit/src/app/marketing/marketing.component.ts
+++ b/src/angular/planit/src/app/marketing/marketing.component.ts
@@ -8,5 +8,7 @@ import { Component } from '@angular/core';
 })
 export class MarketingComponent {
 
+  public hostname = window.location.hostname;
+
   constructor() {}
 }

--- a/src/angular/planit/src/app/shared/login-form/login-form.component.html
+++ b/src/angular/planit/src/app/shared/login-form/login-form.component.html
@@ -41,7 +41,7 @@
       <a routerLink="/forgot-password" [queryParams]="username ? {'username': username} : {}">
         Forgot password?
       </a>
-      <a routerLink="/register">
+      <a *ngIf="hostname !== 'temperate.io'" routerLink="/register">
         Don't have an account?
       </a>
     </div>

--- a/src/angular/planit/src/app/shared/login-form/login-form.component.ts
+++ b/src/angular/planit/src/app/shared/login-form/login-form.component.ts
@@ -16,6 +16,8 @@ export class LoginFormComponent {
 
   public errors: any = {};
 
+  public hostname = window.location.hostname;
+
   @Output() closed: EventEmitter<string> = new EventEmitter();
 
   constructor(private authService: AuthService, private router: Router) {

--- a/src/angular/planit/src/app/shared/navbar/navbar.component.html
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.html
@@ -19,6 +19,7 @@
     <button class="button"
             routerLink="/login">Log In</button>
     <button class="button button-primary"
+            *ngIf="hostname !== 'temperate.io'"
             routerLink="/register">Sign up</button>
   </nav>
 </header>

--- a/src/angular/planit/src/app/shared/navbar/navbar.component.ts
+++ b/src/angular/planit/src/app/shared/navbar/navbar.component.ts
@@ -21,6 +21,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   public user?: User;
   public userSubscription: Subscription;
 
+  public hostname = window.location.hostname;
+
   constructor(public authService: AuthService,
               public router: Router,
               private userService: UserService) {}


### PR DESCRIPTION
Super hacky and annoying that this requires changes
to the template and component.

We'll want to revert this commit before our last
deployment for our early April launch, I opened #881 as a reminder to revert and assigned it to the MVP launch milestone.

### Notes

The intent here is not to disable signup, only to not make it obvious that user's who visit or landing page can signup, as we still want to be able to test the user creation workflow with our testers. 

### Testing

- Change one of the checks to 'localhost' and ensure the link disappears
- Grep for `/register` in the Angular app and make sure I didn't miss any links

Closes #878 
