### PR TITLE
Fix broken links in some browsers due to redirect on weather event fetch

### DIFF
--- a/src/angular/planit/src/app/core/services/weather-event.service.ts
+++ b/src/angular/planit/src/app/core/services/weather-event.service.ts
@@ -18,7 +18,7 @@ export class WeatherEventService {
   }
 
   get(weatherEventId: number): Observable<WeatherEvent> {
-    const url = `${environment.apiUrl}/api/weather-event/${weatherEventId}`;
+    const url = `${environment.apiUrl}/api/weather-event/${weatherEventId}/`;
     return this.apiHttp.get(url)
       .map(resp => resp.json() as WeatherEvent);
   }


### PR DESCRIPTION
## Overview

Fix broken links in some browsers due to redirect on weather event fetch
to endpoint with trailing slash.


## Testing Instructions

 * Go to dashboard
 * 'Take action' and 'Assess' links should work in all browsers
 
 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Fixes #899.

