### PR TITLE
Add unsafe-eval directive to CSP for Heap JS

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
 	map $http_x_forwarded_proto $policy {
 		default "";
-		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com 'self'; font-src heapanalytics.com 'self';";
+		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com 'self'; font-src heapanalytics.com 'self';";
 	}
 
 	include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
## Overview

Should allow the Heap visualizer and other tools to load JS scripts on the Temperate domains.

### Demo

![image](https://user-images.githubusercontent.com/1042475/37786214-755025e4-2dd2-11e8-8ab0-547708662c94.png)

### Notes

I got a CORS errors after loading the visualizer tool. It's not clear if this is because of the configuration of the Temperate dev server, or if some other changes are required to the CSP. But I thought it would be better to see if this change fixes things before trying other changes.

## Testing Instructions

- Make sure your local dev server is running.
- Visit heapanalytics.com/app and login with the user stored in LastPass.
- Go to the Visualizer tool, and type in localhost:4210 as the site to launch it on.
- Verify that the tool loads and can access the site.

Closes #860