### PR TITLE
Set default label for dropdowns

### DIFF
--- a/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.html
+++ b/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.html
@@ -1,6 +1,6 @@
 <div class="button-group" dropdown [isDisabled]="disabled">
   <button dropdownToggle type="button" class="button button-primary dropdown-toggle" [attr.id]="buttonId">
-    {{ options.get(control.value)?.label }}<i class="icon icon-chevron-down"></i>
+    {{ options.get(control.value) ? options.get(control.value)?.label: defaultLabel }}<i class="icon icon-chevron-down"></i>
   </button>
   <ul *dropdownMenu class="dropdown-menu" role="menu">
     <li role="menuitem"

--- a/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.ts
+++ b/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.ts
@@ -15,6 +15,7 @@ export class OptionDropdownComponent implements OnInit {
   @Input() control: FormControl;
   @Input() disabled = false;
   @Input() options: Map<string, OptionDropdownOption>;
+  @Input() defaultLabel = 'Select';
   @Input() buttonId: string = null;
 
   public optionsKeys: string[];


### PR DESCRIPTION
## Overview

For button menu dropdowns, set a label for when nothing has been selected yet.


### Demo

![default_dropdown_text](https://user-images.githubusercontent.com/960264/37837643-1d69b664-2e8c-11e8-8cfe-ec411d6ece4d.png)


### Notes

Didn't see any property yet to support a default text label, so added one. Dropdowns should now be able to override the default dropdown text by setting `defaultLabel` to a string on `app-option-dropdown`.


## Testing Instructions

 * Open a wizard with one or more unpopulated dropdowns
 * Default dropdown text should be 'Select'
 * Dropdown text should update when a selection set
 * Dropdown text should still populate properly when an item is already selected

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #735.
