### PR TITLE
Add tooltip to assessment probability and frequency

### DIFF
--- a/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.html
@@ -5,6 +5,9 @@
   <h3 class="step-title">Hazard</h3>
   <p *ngIf="!isDisabled">
     How will <strong>{{ risk.weather_event.name | lowercase }}</strong> change over time?
+    <span class="icon icon-question-circle"
+          tooltip="{{ probabilityTooltipText }}">
+    </span>
   </p>
 </div>
 
@@ -18,11 +21,11 @@
   <form [formGroup]="form">
     <div class="form-control-container">
       <label for="probability">Probability of this hazard occurring</label>
-        <app-option-dropdown buttonId="probability"
-                             [control]="form.controls['probability']"
-                             [options]="relativeOptions"
-                             [disabled]="isDisabled">
-        </app-option-dropdown>
+      <app-option-dropdown buttonId="probability"
+                           [control]="form.controls['probability']"
+                           [options]="relativeOptions"
+                           [disabled]="isDisabled">
+      </app-option-dropdown>
     </div>
     <div class="form-control-container">
       <label>How often do you expect this hazard to occur in the next five years?</label>

--- a/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/steps/hazard-step/hazard-step.component.ts
@@ -64,6 +64,10 @@ export class HazardStepComponent extends RiskWizardStepComponent<HazardStepFormM
 
   private sessionSubscription: Subscription;
 
+  public probabilityTooltipText = `Viewing related indicators helps you think through probability
+    and frequency. If there are no available data for this hazard, you may want to consult the
+    National Climate Assessment, States At Risk, or use the help icon to contact ICLEI-USA.`;
+
   constructor(protected session: WizardSessionService<Risk>,
               protected riskService: RiskService,
               protected toastr: ToastrService,


### PR DESCRIPTION
## Overview

Add question icon with tooltip on hover.


### Demo

![tooltip_top](https://user-images.githubusercontent.com/960264/37838362-14d062c6-2e8e-11e8-8e04-9988c60b16a7.png)


## Testing Instructions

 * Go to second step ('hazard') of http://localhost:4210/assessment/risk
 * Should have help icon on "How will..." text towards top
 * Should show/hide text on hover enter/exit

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #780.

