### PR TITLE
Disable action wizard fields until action is named

### DIFF
--- a/src/angular/planit/src/app/action-wizard/action-wizard-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/action-wizard-step.component.ts
@@ -12,6 +12,8 @@ import { Action, WizardStepComponent } from '../shared/';
 export abstract class ActionWizardStepComponent<FormModel>
   extends WizardStepComponent<Action, FormModel> implements OnInit {
 
+  public isDisabled = false;
+
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
               protected riskService: RiskService,
@@ -26,6 +28,22 @@ export abstract class ActionWizardStepComponent<FormModel>
     return !model.id ?
       this.actionService.create(model) :
       this.actionService.update(model);
+  }
+
+  setDisabled(action: Action) {
+    this.isDisabled = (action.name === '');
+
+    if (this.form) {
+      if (this.isDisabled) {
+        this.form.disable();
+      } else {
+        this.form.enable();
+      }
+    }
+  }
+
+  shouldSave() {
+    return !this.isDisabled;
   }
 
   finish() {

--- a/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/assess-step/assess-step.component.ts
@@ -63,7 +63,7 @@ export class AssessStepComponent extends ActionWizardStepComponent<AssessStepFor
 
   // return false if user is creating a new action and has nothing typed in
   shouldSave(): boolean {
-    return !!this.action.id || (this.form.valid && !!this.form.controls.name.value);
+    return this.form.valid && !!this.form.controls.name.value;
   }
 
   setupForm(data: AssessStepFormModel) {

--- a/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.html
@@ -1,4 +1,7 @@
 <div class="step-header">
+  <p *ngIf="isDisabled" class="alert alert-warning">
+    You must give this action a name to complete this step.
+  </p>
   <h3 class="step-title">Categories</h3>
   <p>
     Group your actions into categories so you can identify similarities at a
@@ -7,7 +10,7 @@
 </div>
 
 <div class="step-content">
-  <div class="switch-list">
+  <div class="switch-list" [style.pointer-events]="isDisabled ? 'none' : 'auto'">
     <button class="switch-item"
         [ngClass]="{selected: category.selected}"
           *ngFor="let category of actionCategories"

--- a/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/category-step/category-step.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { ToastrService } from 'ngx-toastr';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ActionCategoryService } from '../../../core/services/action-category.service';
 import { ActionService } from '../../../core/services/action.service';
@@ -17,7 +18,7 @@ import { ActionWizardStepComponent } from '../../action-wizard-step.component';
   templateUrl: './category-step.component.html'
 })
 export class CategoryStepComponent extends ActionWizardStepComponent<ActionCategory[]>
-                                   implements OnInit {
+                                   implements OnInit, OnDestroy {
 
   @Input() risk: Risk;
 
@@ -27,6 +28,7 @@ export class CategoryStepComponent extends ActionWizardStepComponent<ActionCateg
 
   public action: Action;
   public actionCategories: ActionCategory[] = [];
+  private sessionSubscription: Subscription;
 
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
@@ -45,6 +47,16 @@ export class CategoryStepComponent extends ActionWizardStepComponent<ActionCateg
       this.actionCategories = categories;
       this.setupForm(this.fromModel(this.session.getData() || new Action({})));
     });
+
+    this.setDisabled(this.action);
+    this.sessionSubscription = this.session.data.subscribe(action => {
+      this.action = action;
+      this.setDisabled(action);
+    });
+  }
+
+  ngOnDestroy() {
+    this.sessionSubscription.unsubscribe();
   }
 
   // toggle button selections on click

--- a/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.html
@@ -1,4 +1,7 @@
 <div class="step-header">
+  <p *ngIf="isDisabled" class="alert alert-warning">
+    You must give this action a name to complete this step.
+  </p>
   <h3 id="funding-title" class="step-title">Funding</h3>
   <p>
     How will you be funding this action? Once this action is created, you will have 

--- a/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/funding-step/funding-step.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { ToastrService } from 'ngx-toastr';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ActionService } from '../../../core/services/action.service';
 import { RiskService } from '../../../core/services/risk.service';
@@ -20,7 +21,7 @@ interface FundingStepFormModel {
   templateUrl: './funding-step.component.html'
 })
 export class FundingStepComponent extends ActionWizardStepComponent<FundingStepFormModel>
-                                  implements OnInit {
+                                  implements OnInit, OnDestroy {
 
   @Input() risk: Risk;
 
@@ -29,6 +30,7 @@ export class FundingStepComponent extends ActionWizardStepComponent<FundingStepF
   public key = ActionStepKey.Funding;
   public navigationSymbol = '5';
   public title = 'Funding';
+  private sessionSubscription: Subscription;
 
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
@@ -43,6 +45,16 @@ export class FundingStepComponent extends ActionWizardStepComponent<FundingStepF
     super.ngOnInit();
     this.action = this.session.getData();
     this.setupForm(this.fromModel(this.action));
+
+    this.setDisabled(this.action);
+    this.sessionSubscription = this.session.data.subscribe(action => {
+      this.action = action;
+      this.setDisabled(action);
+    });
+  }
+
+  ngOnDestroy() {
+    this.sessionSubscription.unsubscribe();
   }
 
   getFormModel(): FundingStepFormModel {

--- a/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.html
@@ -1,4 +1,7 @@
 <div class="step-header">
+  <p *ngIf="isDisabled" class="alert alert-warning">
+    You must give this action a name to complete this step.
+  </p>
   <h3 class="step-title">Details</h3>
   <p>
     Please add some context to this action. You might include what type of work it
@@ -37,11 +40,13 @@
       </label>
       <div id="share" class="button-group form-control-container" data-toggle="buttons" role="radiogroup">
         <button class="button button-primary" role="radio"
+                [disabled]="isDisabled"
                 [ngClass]="{active: !form.controls['isPublic'].value}"
                 (click)="updateIsPublic(false)">
           Keep private
         </button>
         <button class="button button-primary" role="radio"
+                [disabled]="isDisabled"
                 [ngClass]="{active: form.controls['isPublic'].value}"
                 (click)="updateIsPublic(true)">
           Make public

--- a/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/implementation-step/implementation-step.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { ToastrService } from 'ngx-toastr';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ActionTypeService } from '../../../core/services/action-type.service';
 import { ActionService } from '../../../core/services/action.service';
@@ -25,7 +26,7 @@ interface ActionDetailsFormModel {
   templateUrl: './implementation-step.component.html'
 })
 export class ImplementationStepComponent
-  extends ActionWizardStepComponent<ActionDetailsFormModel> implements OnInit {
+  extends ActionWizardStepComponent<ActionDetailsFormModel> implements OnInit, OnDestroy {
 
   @Input() risk: Risk;
 
@@ -38,6 +39,7 @@ export class ImplementationStepComponent
     shareWithCities: 'Public actions can be adapted by other organizations ' +
                      'for their own vulnerability assessments'
   };
+  private sessionSubscription: Subscription;
 
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
@@ -55,6 +57,16 @@ export class ImplementationStepComponent
     this.setupForm(this.fromModel(this.action));
 
     this.actionTypeService.nameList().subscribe(data => this.actionTypes = data);
+
+    this.setDisabled(this.action);
+    this.sessionSubscription = this.session.data.subscribe(action => {
+      this.action = action;
+      this.setDisabled(action);
+    });
+  }
+
+  ngOnDestroy() {
+    this.sessionSubscription.unsubscribe();
   }
 
   public fromModel(model: Action) {

--- a/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.html
@@ -1,4 +1,7 @@
 <div class="step-header">
+  <p *ngIf="isDisabled" class="alert alert-warning">
+    You must give this action a name to complete this step.
+  </p>
   <h3 class="step-title">Outcomes</h3>
   <p>Assuming the implementation of this action is successful, what are the outcomes you hope to achieve?</p>
 </div>

--- a/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/improvements-step/improvements-step.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { ToastrService } from 'ngx-toastr';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ActionService } from '../../../core/services/action.service';
 import { RiskService } from '../../../core/services/risk.service';
@@ -26,7 +27,7 @@ interface ImprovementsStepFormModel {
 })
 export class ImprovementsStepComponent
           extends ActionWizardStepComponent<ImprovementsStepFormModel>
-          implements OnInit {
+          implements OnInit, OnDestroy {
 
   @Input() risk: Risk;
 
@@ -35,6 +36,7 @@ export class ImprovementsStepComponent
   public navigationSymbol = '3';
   public title = 'Outcomes';
   public collaboratorValues: string[];
+  private sessionSubscription: Subscription;
 
   constructor(protected session: WizardSessionService<Action>,
               protected actionService: ActionService,
@@ -56,6 +58,16 @@ export class ImprovementsStepComponent
       // Create a list of collaborator suggestions to display to the user
       this.collaboratorValues = collaborators.map(c => c.name);
     });
+
+    this.setDisabled(this.action);
+    this.sessionSubscription = this.session.data.subscribe(action => {
+      this.action = action;
+      this.setDisabled(action);
+    });
+  }
+
+  ngOnDestroy() {
+    this.sessionSubscription.unsubscribe();
   }
 
   getFormModel(): ImprovementsStepFormModel {

--- a/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.html
+++ b/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.html
@@ -1,4 +1,7 @@
 <div class="step-header">
+  <p *ngIf="isDisabled" class="alert alert-warning">
+    You must give this action a name to save.
+  </p>
   <h3 class="step-title">Review</h3>
 
   <div class="review-feedback warning" *ngIf="!action.isComplete()">

--- a/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.ts
+++ b/src/angular/planit/src/app/action-wizard/steps/review-step/review-step.component.ts
@@ -58,8 +58,10 @@ export class ReviewStepComponent extends ActionWizardStepComponent<any>
 
     this.riskService.get(this.action.risk).subscribe(r => this.risk = r);
 
-    this.sessionSubscription = this.session.data.subscribe(a => {
-      this.action = a;
+    this.setDisabled(this.action);
+    this.sessionSubscription = this.session.data.subscribe(action => {
+      this.action = action;
+      this.setDisabled(action);
     });
   }
 


### PR DESCRIPTION
## Overview

Much like the risk wizard, the form fields of the action wizard should be disabled until the first step is complete. Users can skip to any step in the process, but they are prevented from entering any data until they go back to the first step and give the action a name. The implementation here is completely based on the implementation of the same behavior in the risk wizard.

### Demo

![mar-23-2018 13-56-37](https://user-images.githubusercontent.com/1042475/37846579-667e6f1c-2ea4-11e8-8a14-04588436141b.gif)

## Testing Instructions

- Open the action wizard for a risk that doesn't currently have an action.
- Click through the steps using the numbers of the left, and verify all of the steps have disabled forms besides the first one.
- Go back to the first step, and enter an action name.
- Proceed through the wizard and verify all of the form fields are now enabled.

Closes #950