### PR TITLE
Close modal when visiting methodology page

### DIFF
--- a/src/angular/planit/src/app/organization-wizard/add-city-modal/add-city-modal.component.html
+++ b/src/angular/planit/src/app/organization-wizard/add-city-modal/add-city-modal.component.html
@@ -48,7 +48,7 @@
     </button>
   </header>
   <div class="modal-body">
-    We'll get back to you as soon as possible. In the meantime, check out our <a routerLink="/methodology">resources page.</a>
+    We'll get back to you as soon as possible. In the meantime, check out our <a routerLink="/methodology" (click)="modalRef.hide()">methodology page</a>.
     <footer class="modal-footer">
       <button class="button button-primary" (click)="modalRef.hide()">Okay</button>
     </footer>


### PR DESCRIPTION
## Overview

Ensure the "Add City" modal is closed when the user clicks the methodology page link in the modal. Also, rename the link text from "resources" to "methodology".

### Demo

![mar-23-2018 15-33-04](https://user-images.githubusercontent.com/1042475/37849838-86289da0-2eaf-11e8-967a-8f09cd3822af.gif)

## Testing Instructions

- Create a new user.
- Proceed to the organization setup wizard.
- Click the link to add a new city.
- Fill out and submit the form.
- On the next modal, click the link to visit the methodology page.
- Verify the modal is closed and the methodology page is loaded.

Closes #939