### PR TITLE
Hide errors for plan date until value is entered

### DIFF
--- a/src/angular/planit/src/app/create-plan/plan-wizard/steps/due-date-step/due-date-step.component.html
+++ b/src/angular/planit/src/app/create-plan/plan-wizard/steps/due-date-step/due-date-step.component.html
@@ -17,7 +17,7 @@
              bsDatepicker [(ngModel)]="planDueDate"
              [minDate]="minDate"
              [bsConfig]="{ containerClass: 'theme-default', showWeekNumbers: false }">
-      <div class="form-control-error" *ngIf="form.controls.plan_due_date.errors && (form.controls.plan_due_date.dirty || form.controls.plan_due_date.touched)">
+      <div class="form-control-error" *ngIf="form.controls.plan_due_date.errors && form.controls.plan_due_date.dirty">
         <span *ngIf="form.controls.plan_due_date.errors.required">Enter the date that you and your team expect to finish this plan. Don&rsquo;t worry, you can change this later</span>
         <div *ngIf="form.controls.plan_due_date.errors.bsDate">
           <span *ngIf="form.controls.plan_due_date.errors.bsDate.invalid &&


### PR DESCRIPTION
## Overview

The use of the Bootstrap calendar module triggered the date field to become "touched" once the user clicked the calendar because the field would lose focus. We now only check for errors once the field has
been "dirty", which means it's value has changed.

### Demo

![mar-26-2018 16-10-32](https://user-images.githubusercontent.com/1042475/37930703-89610cf0-3111-11e8-8eac-5b87cc0b7a33.gif)

### Notes

Documentation on touch/untouched and pristine/dirty: https://angular.io/guide/form-validation#why-check-dirty-and-touched

## Testing Instructions

- For a new account, proceed to the plan wizard.
- Interact with the date field and calendar, and verify an error is not displayed unless an invalid value is entered.

Connects #836