### PR TITLE
Remove space between concern unit and value, hide unit for days

### DIFF
--- a/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.html
+++ b/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.html
@@ -23,10 +23,7 @@
         {{ weatherEvent.name }}
       </div>
       <div class="concern-stats" *ngIf="hasConcern(weatherEvent)">
-        {{ format(weatherEvent.concern) }}
-        <ng-template [ngIf]="hasUnits(weatherEvent.concern)">
-          {{ units(weatherEvent.concern) }}
-        </ng-template>
+        {{ format(weatherEvent.concern) }}<ng-template [ngIf]="hasUnits(weatherEvent.concern)">{{ units(weatherEvent.concern) }}</ng-template>
         {{ weatherEvent.concern.tagline }}
       </div>
     </div>

--- a/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.ts
+++ b/src/angular/planit/src/app/shared/top-concerns/top-concerns.component.ts
@@ -33,7 +33,7 @@ export class TopConcernsComponent {
   }
 
   hasUnits(concern: Concern): boolean {
-    return concern.units !== 'count';
+    return concern.units !== 'count' && concern.units !== 'days';
   }
 
   isReadOnly(weatherEvent: WeatherEvent) {

--- a/src/django/planit_data/fixtures/concerns.json
+++ b/src/django/planit_data/fixtures/concerns.json
@@ -34,8 +34,8 @@
         "indicator": [
             "max_consecutive_dry_days"
         ],
-        "tagline_positive": "longer dry spells",
-        "tagline_negative": "shorter dry spells",
+        "tagline_positive": "more days in the longest yearly dry spell",
+        "tagline_negative": "fewer days in the longest yearly dry spell",
         "is_relative": false,
         "static_value": null,
         "static_units": ""


### PR DESCRIPTION
## Overview

Remove space between concern unit and value, hide unit for days

### Demo

![screenshot from 2018-03-27 13-53-49](https://user-images.githubusercontent.com/4432106/37985262-505410b4-31c6-11e8-81cd-64edcf9c4113.png)


## Testing Instructions

 * `scripts/manage loaddata concerns`
 * `scripts/server`

 - [x] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #931
