### PR TITLE
Replace indicator filter buttons with a dropdown

### DIFF
--- a/src/angular/planit/src/app/indicators/indicators.component.html
+++ b/src/angular/planit/src/app/indicators/indicators.component.html
@@ -15,9 +15,8 @@
       <div class="indicators-header">
         <h2>Indicators</h2>
         <div class="indicator-filters" *ngIf="filters?.size">
-          <div class="filter-header">
-            <label for="filter-indicators">Filter by your selected hazards:</label>
-            <div id="filter-indicators" class="button-group">
+          <div class="filter-container">
+            <div class="button-group">
               <app-option-dropdown
                 [control]="form.controls['filter']"
                 buttonId="filters"

--- a/src/angular/planit/src/app/indicators/indicators.component.ts
+++ b/src/angular/planit/src/app/indicators/indicators.component.ts
@@ -74,7 +74,7 @@ export class IndicatorsComponent implements OnInit {
   }
 
   private setupFilters(weatherEvents: WeatherEvent[]) {
-    this.filters.set(null, { label: 'No filter' , description: '' });
+    this.filters.set(null, { label: 'Filter by hazard...' , description: '' });
 
     weatherEvents.forEach((weatherEvent) => {
       if (weatherEvent.indicators && weatherEvent.indicators.length) {

--- a/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.html
+++ b/src/angular/planit/src/app/shared/option-dropdown/option-dropdown.component.html
@@ -7,7 +7,7 @@
         *ngFor="let opt of optionsKeys"
         [ngClass]="{active: opt === control.value}">
       <a class="dropdown-item" (click)="setOption(opt)">
-        <span class="dropdown-label">{{ options.get(opt)?.label }}</span>
+        <span [ngClass]="{'dropdown-label-only': !options.get(opt)?.description, 'dropdown-label': options.get(opt)?.description}">{{ options.get(opt)?.label }}</span>
         <span class="dropdown-description" *ngIf="options.get(opt)?.description">{{ options.get(opt)?.description }}</span>
       </a>
     </li>

--- a/src/angular/planit/src/assets/sass/pages/_indicators.scss
+++ b/src/angular/planit/src/assets/sass/pages/_indicators.scss
@@ -3,28 +3,25 @@ app-indicators {
     max-width: 92rem;
   }
 
-  .indicator-filters {
-    margin-bottom: $space-large;
+  .top-concerns.empty-state {
+    background: $white;
+  }
+  
+  .indicators-header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: $space-medium;
 
-    .button-group {
-      flex-wrap: wrap;
-
-      .button {
-        margin-bottom: $space-tiny;
-        flex: 0 0 auto;
-      }
+    > h2 {
+      margin-bottom: 0;
     }
+  }
 
-    .filter-header {
-      margin-bottom: 0.35rem;
-
-      label {
-        margin-right: $space-medium;
-      }
-
-      .reset-button {
-        margin-left: $space-large;
-      }
+  .filter-container {
+    .dropdown-menu {
+      right: 0;
+      left: auto;
     }
   }
 


### PR DESCRIPTION
## Overview

This makes for a better UI/UX and can handle more options than a row of buttons.

Also, hide charts on indicator page when a filter is applied, instead of expanding the relevant charts.

### Demo

![mar-28-2018 11-31-36](https://user-images.githubusercontent.com/1042475/38039648-b8bfd06a-327b-11e8-9d05-fc15cf1322ea.gif)

## Testing Instructions

- Navigate to the indicators page.
- Interact with the filter dropdown menu, and ensure charts are removed and added as you select different options.
- Ensure that all of your chosen hazards are listed in the menu.

Closes #807 