### PR TITLE
Disable multiselect add button when no text in input

### DIFF
--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.html
@@ -14,7 +14,7 @@
          [typeaheadOptionsInScrollableView]="5"
          [typeaheadOptionsLimit]="100"
          [container]="'body'">
-  <button class="button button-icon" type="button" (click)="onAdd()"><i class="icon-plus"></i></button>
+  <button class="button button-icon" type="button" [disabled]="!selected.length" (click)="onAdd()"><i class="icon-plus"></i></button>
 </div>
 <div class="input-group" *ngIf="isDisabled">
   <input class="form-control" placeholder="Type to search. Add new item by clicking the +" disabled [attr.id]="inputId">


### PR DESCRIPTION
## Overview

Attempts to clarify user interaction with the plus button by only enabling it when it would actually do something. 

### Demo

![mar-29-2018 09-41-12](https://user-images.githubusercontent.com/1818302/38092414-2b3c62ec-3336-11e8-9a85-0d5d4b2accd0.gif)

## Testing Instructions

- Ensure freeform multiselect still works as expected in the risk and action wizards
- Ensure that the "unsaved" and the disabled add button work correctly together -- the plus button should be enabled when you return to the step and the input is pre-filled with an unsaved value.

Closes #984
