### PR TITLE
City Profile: About

### DIFF
--- a/src/angular/planit/src/app/dashboard/city-profile/city-profile.component.html
+++ b/src/angular/planit/src/app/dashboard/city-profile/city-profile.component.html
@@ -4,10 +4,13 @@
       <h1 class="page-title-large">City Profile</h1>
       <p class="paragraph-intro">Include information about your city and its past achievements as well as any long-term goals you hope to achieve.</p>
       <p>These questions can be answered at any point in the process of developing your plan.</p>
+      <button class="button button-primary" (click)="save()">Save changes</button>
     </header>
 
     <section class="page-section">
       <accordion *ngIf="cityProfile">
+
+        <!-- START About section -->
         <accordion-group [(isOpen)]="isOpen[sections.About]">
           <header accordion-heading>
             <h2 class="panel-label">About your city</h2>
@@ -15,19 +18,84 @@
             <span class="icon icon-accordion" [ngClass]="isOpen[sections.About] ? 'icon-chevron-down' : 'icon-chevron-right'"></span>
           </header>
           <div class="form-control-container">
-            <label for="economic-sector">
-              Economic sector
+            <label for="economic-sector" class="profile-required">
+              What is your main economic sector?
             </label>
-            <input id="economic-sector" class="form-control"
-                   type="text"
-                   [(ngModel)]="cityProfile.about_economic_sector"
-                   [typeahead]="sectors"
-                   typeaheadMinLength="0">
+            <select class="form-control" [(ngModel)]="cityProfile.about_economic_sector">
+              <option [value]="''">---</option>
+              <option *ngFor="let sector of sectors" [value]="sector">{{ sector }}</option>
+            </select>
+          </div>
+          <div class="form-control-container">
+            <label for="operational-budget" class="profile-required">
+              What is your operational budget (USD)?
+            </label>
+            <input id="operational-budget" class="form-control"
+                   type="number"
+                   min="0"
+                   [(ngModel)]="cityProfile.about_operational_budget_usd">
+            <div *ngIf="errors.about_operational_budget_usd" class="form-control-error">
+              <p *ngFor="let error of errors.about_operational_budget_usd">{{ error }}</p>
+            </div>
+          </div>
+          <div class="form-control-container">
+            <label for="adaptation-status">
+              What is the status of your adaptation or resilience commitment?
+            </label>
+            <select id="adaptation-status"
+                    class="form-control"
+                    [(ngModel)]="cityProfile.about_adaptation_status">
+              <option [value]="''">---</option>
+              <option *ngFor="let opt of commitments" [value]="opt.name">{{ opt.label }}</option>
+            </select>
+          </div>
+          <div class="form-control-container">
+            <label for="commitment-status">
+              What is the status of your commitment to climate change mitigation?
+            </label>
+            <select id="commitment-status"
+                    class="form-control"
+                    [(ngModel)]="cityProfile.about_commitment_status">
+              <option [value]="''">---</option>
+              <option *ngFor="let opt of commitments" [value]="opt.name">{{ opt.label }}</option>
+            </select>
+          </div>
+          <div class="form-control-container">
+            <label for="mitigation-status">
+              What is the status of your climate change mitigation plan?
+            </label>
+            <select id="mitigation-status"
+                    class="form-control"
+                    [(ngModel)]="cityProfile.about_mitigation_status">
+              <option [value]="''">---</option>
+              <option *ngFor="let opt of commitments" [value]="opt.name">{{ opt.label }}</option>
+            </select>
+          </div>
+          <div class="form-control-container">
+            <label for="sustainability-description">
+              Describe the sustainability goal of your city
+            </label>
+            <textarea id="sustainability-description" class="form-control" rows="6"
+                   [(ngModel)]="cityProfile.about_sustainability_description"></textarea>
+          </div>
+          <div class="form-control-container">
+            <label for="sustainability-progress">
+              Describe your city's progress on meeting the goal above
+            </label>
+            <textarea id="sustainability-progress" class="form-control" rows="6"
+                   [(ngModel)]="cityProfile.about_sustainability_progress"></textarea>
+          </div>
+          <div class="form-control-container">
+            <label for="master-planning">
+              Describe the extent to which adaptation planning has been incorporated into master planning
+            </label>
+            <textarea id="master-planning" class="form-control" rows="6"
+                   [(ngModel)]="cityProfile.about_master_planning"></textarea>
           </div>
         </accordion-group>
+        <!-- END About section -->
+
       </accordion>
     </section>
-
-    <button class="button button-primary" (click)="save()">Save</button>
   </main>
 </div>

--- a/src/angular/planit/src/app/dashboard/city-profile/city-profile.component.ts
+++ b/src/angular/planit/src/app/dashboard/city-profile/city-profile.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { TypeaheadMatch } from 'ngx-bootstrap';
+import { ToastrService } from 'ngx-toastr';
 import { Subscription } from 'rxjs/Rx';
 
 import { CityProfileService } from '../../core/services/city-profile.service';
@@ -13,13 +15,16 @@ import { CityProfile, CityProfileOption, CityProfileSection } from '../../shared
 export class CityProfileComponent implements OnInit {
 
   public cityProfile: CityProfile;
+  public errors: any = {};
   public isOpen = {};
   public sections = CityProfileSection;
 
   // Properties to store field choices
+  public commitments: CityProfileOption[] = [];
   public sectors: string[] = [];
 
   constructor(private cityProfileService: CityProfileService,
+              private toastr: ToastrService,
               private userService: UserService) {
   }
 
@@ -31,9 +36,23 @@ export class CityProfileComponent implements OnInit {
     this.cityProfileService.listEconomicSectors().subscribe(s => {
       this.sectors = s.map(option => option.name);
     });
+    this.cityProfileService.listCommitmentStatuses().subscribe(commitments => {
+      this.commitments = commitments;
+    });
   }
 
   save() {
-    this.cityProfileService.update(this.cityProfile).subscribe(p => this.cityProfile = p);
+    this.cityProfileService.update(this.cityProfile).subscribe(p => {
+      this.errors = {};
+      this.cityProfile = p;
+      this.toastr.success('Changes saved successfully.');
+    }, error => {
+      this.errors = error.json();
+      const message = `
+        There was an error saving your city profile.
+        Please check all form fields and try again.
+      `;
+      this.toastr.error(message);
+    });
   }
 }

--- a/src/angular/planit/src/assets/sass/pages/_city-profile.scss
+++ b/src/angular/planit/src/assets/sass/pages/_city-profile.scss
@@ -1,5 +1,11 @@
 app-city-profile {
   .main-container .main-content {
     max-width: 92rem;
+
+    .profile-required:after {
+      margin-left: 0.4rem;
+      content: '*';
+      color: $brand-danger;
+    }
   }
 }


### PR DESCRIPTION
## Overview

Implements the input forms for the about section of the city profile.

### Demo

![screen shot 2018-03-29 at 11 13 52](https://user-images.githubusercontent.com/1818302/38097048-5b903ef8-3342-11e8-92e8-f6150e9d5942.png)
![screen shot 2018-03-29 at 11 14 02](https://user-images.githubusercontent.com/1818302/38097053-5d300d92-3342-11e8-8e2d-961137efaf9a.png)
![screen shot 2018-03-29 at 11 14 15](https://user-images.githubusercontent.com/1818302/38097055-5e91009c-3342-11e8-9342-d6da8177355f.png)

### Notes

I stopped short of adding a form to take advantage of validators. The only field that would benefit is the budget number, but apparently the default `min` validator is [only available as a function](https://angular.io/api/forms/Validators) and not a directive. It might be enough of an edge case to avoid implementation now, but I can revisit if desired.

## Testing Instructions

- Go to the city profile and enter data. Ensure that changes are persisted when clicking save.

Closes #502 
