### PR TITLE
Add FAQ for data primer

### DIFF
--- a/src/angular/planit/src/app/faq/faq.component.html
+++ b/src/angular/planit/src/app/faq/faq.component.html
@@ -65,11 +65,11 @@
             </p>
           </li>
           <li class="faq">
-              <h4 class="question">I'm new to climate change data and need a primer. Where can I start?</h4>
-              <p class="answer">
-                  Check out our <a href="https://s3-us-west-2.amazonaws.com/temperate/data_intro/story_html5.html">introduction to the data here</a>.
-              </p>
-            </li>
+            <h4 class="question">I'm new to climate change data and need a primer. Where can I start?</h4>
+            <p class="answer">
+              Check out our <a href="https://s3-us-west-2.amazonaws.com/temperate/data_intro/story_html5.html" target="_blank">introduction to the data here</a>.
+            </p>
+          </li>
         </ul>
       </div>
   </main>


### PR DESCRIPTION
## Overview
Adds a FAQ entry offering a beginner's primer on climate data.

### Demo
<img width="457" alt="screen shot 2018-03-30 at 11 28 22 am" src="https://user-images.githubusercontent.com/1032849/38143235-8dfd173c-340d-11e8-8e11-14ead917b550.png">

### Notes
- The link points to a file that is not under our control, but is managed directly by ICLEI

## Testing Instructions
- Open the FAQ page from the site footer
  - You should see an entry for the primer

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #1003 