### PR TITLE
Add separate user email for plan submission

### DIFF
--- a/src/django/planit_data/templates/email/submit_plan_user_email.html
+++ b/src/django/planit_data/templates/email/submit_plan_user_email.html
@@ -1,0 +1,10 @@
+{% load premailer %}
+{% premailer %}
+<html>
+    <p>
+        We've received the Temperate plan for due date {{ date_due }} you submitted {{ date_submitted }} for {{ organization_name }}. ICLEI will reach out shortly to coordinate a review process. In the meantime, feel free to continue making changes as necessary.
+    </p>
+
+</html>
+
+{% endpremailer %}

--- a/src/django/planit_data/templates/email/submit_plan_user_email.txt
+++ b/src/django/planit_data/templates/email/submit_plan_user_email.txt
@@ -1,0 +1,1 @@
+We've received the Temperate plan for due date {{ date_due }} you submitted {{ date_submitted }} for {{ organization_name }}. ICLEI will reach out shortly to coordinate a review process. In the meantime, feel free to continue making changes as necessary.

--- a/src/django/planit_data/templates/email/submit_plan_user_email_subject.txt
+++ b/src/django/planit_data/templates/email/submit_plan_user_email_subject.txt
@@ -1,0 +1,1 @@
+Temperate plan submission: {{ organization_name }}

--- a/src/django/planit_data/tests/test_views.py
+++ b/src/django/planit_data/tests/test_views.py
@@ -58,13 +58,11 @@ class PlanSubmitViewTestCase(APITestCase):
         url = reverse('submit-plan')
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(len(mail.outbox), 1)
-        message = mail.outbox[0]
-        TO_EMAIL = [settings.PLAN_SUBMISSION_EMAIL]
-        BCC_EMAIL = [self.user.email]
-        self.assertListEqual(message.recipients(), TO_EMAIL + BCC_EMAIL)
-        self.assertEqual(len(message.attachments), 1)
-        filename, content, mimetype = message.attachments[0]
+        self.assertEqual(len(mail.outbox), 2)
+        first_message = mail.outbox[0]
+        self.assertListEqual(first_message.recipients(), [settings.PLAN_SUBMISSION_EMAIL])
+        self.assertEqual(len(first_message.attachments), 1)
+        filename, content, mimetype = first_message.attachments[0]
         self.assertIn('.csv', filename)
         self.assertGreater(len(content), 0)
         self.assertEqual(mimetype, 'text/csv')
@@ -78,13 +76,15 @@ class PlanSubmitViewTestCase(APITestCase):
         url = reverse('submit-plan')
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 2)
 
-        TO_EMAIL = [settings.PLAN_SUBMISSION_EMAIL]
-        BCC_EMAIL = list(PlanItUser.objects.filter(primary_organization=organization)
-                                           .values_list('email', flat=True))
-        message = mail.outbox[0]
-        self.assertListEqual(message.recipients(), TO_EMAIL + BCC_EMAIL)
+        to_email = [settings.PLAN_SUBMISSION_EMAIL]
+        user_email = list(PlanItUser.objects.filter(primary_organization=organization)
+                                            .values_list('email', flat=True))
+        first_message = mail.outbox[0]
+        second_message = mail.outbox[1]
+        self.assertListEqual(first_message.recipients(), to_email)
+        self.assertListEqual(second_message.recipients(), user_email)
 
 
 class ConcernViewSetTestCase(APITestCase):

--- a/src/django/planit_data/views.py
+++ b/src/django/planit_data/views.py
@@ -109,6 +109,7 @@ class PlanSubmitView(PlanView):
 
             # Create email context
             template_path = 'email/submit_plan_email'
+            user_template_path = 'email/submit_plan_user_email'
             due_date = user_org.plan_due_date.isoformat() if user_org.plan_due_date else '--'
             org_user_emails = list(PlanItUser.objects.filter(primary_organization=user_org)
                                                      .values_list('email', flat=True))
@@ -129,7 +130,14 @@ class PlanSubmitView(PlanView):
                 settings.DEFAULT_FROM_EMAIL,
                 [settings.PLAN_SUBMISSION_EMAIL],
                 context=context,
-                bcc=org_user_emails,
+                attachments=[plan_attachment]
+            )
+
+            send_html_email(
+                user_template_path,
+                settings.DEFAULT_FROM_EMAIL,
+                org_user_emails,
+                context=context,
                 attachments=[plan_attachment]
             )
         return Response(None, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Overview

Add separate user email for plan submission

## Demo

![image](https://user-images.githubusercontent.com/960264/38147470-7847b8bc-3420-11e8-98ec-efdcd3d4320d.png)
