### PR TITLE
Switch modal buttons on confirm dialog

### DIFF
--- a/src/angular/planit/src/app/shared/confirmation-modal/confirmation-modal.component.html
+++ b/src/angular/planit/src/app/shared/confirmation-modal/confirmation-modal.component.html
@@ -2,9 +2,9 @@
   <p *ngIf="tagline">{{ tagline }}</p>
   <footer class="modal-footer">
     <button class="button"
-            (click)="close(false)">{{ cancelText }}</button>
-    <button class="button"
             [ngClass]="confirmButtonClass"
             (click)="close(true)">{{ confirmText }}</button>
+    <button class="button"
+            (click)="close(false)">{{ cancelText }}</button>
   </footer>
 </app-modal-template>


### PR DESCRIPTION
## Overview

Swap button order on confirmation modal dialog, to match dominant pattern in app.

### Demo

![screen shot 2018-04-02 at 12 45 24 pm](https://user-images.githubusercontent.com/128699/38205428-939e2f0a-3674-11e8-9aad-beaae75923b6.png)


## Testing Instructions

 * Submit a plan. Note the button order.

Closes #896 
