### PR TITLE
Invalidate user cache on Organization create and update

### DIFF
--- a/src/angular/planit/src/app/core/services/organization.service.ts
+++ b/src/angular/planit/src/app/core/services/organization.service.ts
@@ -7,11 +7,14 @@ import { APICacheService } from 'climate-change-components';
 import { environment } from '../../../environments/environment';
 import { Organization } from '../../shared';
 import { PlanItApiHttp } from './api-http.service';
+import { UserService } from './user.service';
 
 @Injectable()
 export class OrganizationService {
 
-  constructor(private apiHttp: PlanItApiHttp, private cache: APICacheService) {}
+  constructor(private apiHttp: PlanItApiHttp,
+              private userService: UserService,
+              private cache: APICacheService) {}
 
   private formatOrganization(organization: Organization): any {
     const formattedOrganization = cloneDeep(organization);
@@ -26,7 +29,7 @@ export class OrganizationService {
     const url = `${environment.apiUrl}/api/organizations/`;
     return this.apiHttp.post(url, this.formatOrganization(organization)).map(resp => {
       organization = new Organization(resp.json());
-      this.cache.clear('CORE_USERSERVICE_CURRENT');
+      this.userService.invalidate();
       return organization;
     });
   }
@@ -36,7 +39,7 @@ export class OrganizationService {
     // PATCH instead of PUT here to avoid errors regarding required fields that are already set
     return this.apiHttp.patch(url, this.formatOrganization(organization)).map(resp => {
       organization = new Organization(resp.json());
-      this.cache.clear('CORE_USERSERVICE_CURRENT');
+      this.userService.invalidate();
       return organization;
     });
   }


### PR DESCRIPTION
## Overview
For some not well understood reason, when #1033 swapped to using the CCC cache, the behavior the OrganizationService already had of deleting the cached user became insufficient. This changes the OrganizationService to use the UserService.invalidate() method, which clears the cache and forces a refresh of the user data, notifying any subscribers of the new organization state.

## Testing Instructions
- In the admin panel, set your user's primary organization to `------`
- Attempt to create a new organization
- You should be able to advance past the "Invite users" page

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #1040 
