### PR TITLE
Bugfix help modal description not sent to SalesForce

### DIFF
--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.html
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.html
@@ -43,7 +43,8 @@
       </div>
       <footer class="modal-footer">
         <div class="button-group">
-          <button form="help" type="submit" class="button button-primary" [disabled]="submitPending"
+          <button form="help" type="submit" class="button button-primary"
+            [ngClass]="{'disabled': submitPending}"
             (click)="closeModal(500)">Send</button>
           <button type="button" class="button"
             data-dismiss="modal" aria-label="Close" (click)="closeModal()">Cancel</button>


### PR DESCRIPTION
## Overview

It looks like we lost the name attribute accidentally in     https://github.com/azavea/temperate/commit/f93b95d249c66fd8f6f88b39cc0822061a03b405#diff-65113efe52763141b3fd490a88dd0c62

This PR adds it back, which means the form sends the text in the description field again.

## Demo

![screen shot 2018-04-02 at 14 54 40](https://user-images.githubusercontent.com/1818302/38210559-cb2c58f0-3685-11e8-9322-e5581ab134a1.png)

![screen shot 2018-04-02 at 14 47 00](https://user-images.githubusercontent.com/1818302/38210543-c0c5cdd8-3685-11e8-9d36-7670107e6c73.png)


### Notes

ICLEI states that the `--` above and below the description text in the confirmation email is static text meant to delineate the description text, not fields that should be filled with data but aren't. He's satisfied with the current state of the form and data he's receiving.

I added a comment in the form html to note the importance of the name attribute for future devs.

## Testing Instructions

Submit a request to the help modal form, with some recognizable description text, and ensure the text is reflected back at you in the confirmation email you receive from salesforce

Closes #1039 
