### PR TITLE
Change input type from 'input' to 'text'

### DIFF
--- a/src/angular/planit/src/app/shared/new-user-form/new-user-form.component.html
+++ b/src/angular/planit/src/app/shared/new-user-form/new-user-form.component.html
@@ -53,7 +53,7 @@
       <label for="password">Password</label>
       <div class="input-group">
         <input class="form-control"
-               [type]="passwordVisible ? 'input' : 'password'"
+               [type]="passwordVisible ? 'text' : 'password'"
                required
                autocomplete="new-password"
                [(ngModel)]="model.password"


### PR DESCRIPTION
## Overview

Fixes the "reveal password" button for IE11. 'input' is not a valid value for the type attribute of an input element.  The default is 'text', which other browsers defaulted to when 'input' was specified.

## Testing Instructions

- Test the "reveal password" button on the registration page in all browsers.

Closes #1026