### PR TITLE
Close modal with timed delay when submitting salesforce form

### DIFF
--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.html
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.html
@@ -38,7 +38,7 @@
       </div>
       <footer class="modal-footer">
         <div class="button-group">
-          <button form="help" type="submit" class="button button-primary"
+          <button form="help" type="submit" class="button button-primary" [disabled]="submitPending"
             (click)="closeModal(500)">Send</button>
           <button type="button" class="button"
             data-dismiss="modal" aria-label="Close" (click)="closeModal()">Cancel</button>

--- a/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
+++ b/src/angular/planit/src/app/shared/help-modal/help-modal.component.ts
@@ -18,6 +18,7 @@ export class HelpModalComponent implements OnInit, OnDestroy {
   public loginSubscription: Subscription;
   public logoutSubscription: Subscription;
   public modalRef: BsModalRef;
+  public submitPending = false;
   public user?: User;
   public url: string;
   public userSubscription: Subscription;
@@ -50,6 +51,7 @@ export class HelpModalComponent implements OnInit, OnDestroy {
   }
 
   public openModal(template: TemplateRef<any>) {
+    this.submitPending = false;
     this.modalRef = this.modalService.show(template, {animated: false});
   }
 
@@ -57,6 +59,9 @@ export class HelpModalComponent implements OnInit, OnDestroy {
   //  form has time to be sent before the modal is closed and the form is destroyed in the DOM
   public closeModal(delay = 0) {
     if (this.modalRef) {
+      if (delay > 0) {
+        this.submitPending = true;
+      }
       window.setTimeout(() => {
         this.modalRef.hide();
         this.modalRef = undefined;


### PR DESCRIPTION
### Testing

Ensure you're able to submit the form with any and all ad blockers disabled and that you receive a confirmation email upon submission.


Closes #1053 
