### PR TITLE
Fix indicator charts

### DIFF
--- a/src/angular/planit/src/app/shared/models/location.model.ts
+++ b/src/angular/planit/src/app/shared/models/location.model.ts
@@ -10,6 +10,8 @@ export class Location {
   type: string;
   geometry: Point;
   properties: LocationProperties;
+  id: string;
+  dataset: Array<string>;
 
   constructor(object: Object) {
     Object.assign(this, object);

--- a/src/angular/planit/src/app/shared/models/organization.model.ts
+++ b/src/angular/planit/src/app/shared/models/organization.model.ts
@@ -30,6 +30,8 @@ export class Organization {
       this.subscription_end_date = new Date(this.subscription_end_date);
     }
     if (this.location) {
+      this.location.id = this.location.properties.api_city_id;
+      this.location.properties['datasets'] = ['LOCA'],
       this.location = new Location(this.location);
     }
   }


### PR DESCRIPTION
## Overview

In #1025, we switched from using the city object returned from the city endpoint, to the city object stored with the organization. The city data stored with an organization does not include the top-level id attribute or the dataset attribute, both of which are required for the indicator page.

The changes to the location model not included, this is a temporary fix for launch. At a later date, we should reintegrate the city service instead of manually specifying and hardcoding the id and dataset values. We do not have 'NEX-GDDP' for some cities, so it is not included in the
list of datasets.

### Demo

![image](https://user-images.githubusercontent.com/1042475/38256107-8af137a0-372b-11e8-9a36-7cc2f91b44ab.png)

### Notes

Follow-up issue: https://github.com/azavea/temperate/issues/1064

## Testing Instructions

- Visit the indicator page, and verify that the charts work and that there are no console errors.

Closes #1058