### PR TITLE
Fixup centering of empty state for hazards and community systems

### DIFF
--- a/src/angular/planit/src/assets/sass/components/_top-concerns.scss
+++ b/src/angular/planit/src/assets/sass/components/_top-concerns.scss
@@ -117,6 +117,7 @@
     font-style: $empty-state-text-style;
     max-width: $empty-state-text-max-width;
     margin: 0 auto;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Overview
Closes #1065

### Demo
![screen shot 2018-04-03 at 10 56 21 am](https://user-images.githubusercontent.com/5672295/38257537-649bd454-372e-11e8-8bf7-3d75c5b7f7ba.png)
![screen shot 2018-04-03 at 10 59 32 am](https://user-images.githubusercontent.com/5672295/38257538-64a4c0a0-372e-11e8-885b-e5e9c80ecb7b.png)
![screen shot 2018-04-03 at 10 59 46 am](https://user-images.githubusercontent.com/5672295/38257540-64b530a2-372e-11e8-96d0-97d4346f61e0.png)


## Testing Instructions
* Check create a plan in IE11
* Check Add hazard modal in IE11

~- [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.~

