### PR TITLE
Show all organization users on the Settings page

### DIFF
--- a/src/angular/planit/src/app/settings/settings.component.html
+++ b/src/angular/planit/src/app/settings/settings.component.html
@@ -38,7 +38,10 @@
         <div class="form-control-container">
           <label>Invite a colleague</label>
           <app-user-emails formControlName="invites" aria-labelledby="invite-header" (added)="inviteUser($event)"></app-user-emails>
-          <div class="form-control-hint">Invited colleagues will automatically join your organization and can collaborate on your plan.</div>
+          <div class="form-control-hint">
+            Invited colleagues will automatically join your organization and can collaborate on your plan.
+            <p>To remove someone from your organization, please click &ldquo;Send us a message&rdquo; for assistance.</p>
+          </div>
           <div class="form-control-error"> </div>
         </div>
       </section>

--- a/src/angular/planit/src/app/settings/settings.component.ts
+++ b/src/angular/planit/src/app/settings/settings.component.ts
@@ -83,6 +83,8 @@ export class SettingsComponent implements OnInit {
       });
     }, () => {
       this.toastr.error('Something went wrong, please try again.');
+      // If the save failed, reset the form controls
+      this.toForm(this.user);
     });
   }
 
@@ -93,6 +95,6 @@ export class SettingsComponent implements OnInit {
 
   private toForm(user: User) {
     this.form.controls.plan_due_date.setValue(user.primary_organization.plan_due_date);
-    this.form.controls.invites.setValue(user.primary_organization.invites);
+    this.form.controls.invites.setValue(user.primary_organization.users);
   }
 }

--- a/src/angular/planit/src/app/shared/models/organization.model.ts
+++ b/src/angular/planit/src/app/shared/models/organization.model.ts
@@ -16,6 +16,7 @@ export class Organization {
   weather_events: number[];
   community_systems: number[];
   invites?: string[];
+  users?: string[];
 
   constructor(object: Object) {
     Object.assign(this, object);

--- a/src/angular/planit/src/assets/sass/pages/_settings.scss
+++ b/src/angular/planit/src/assets/sass/pages/_settings.scss
@@ -4,4 +4,14 @@
   h3 {
     font-size: $text-medium;
   }
+
+  app-user-emails {
+    .selected-option > button {
+      display: none;
+    }
+
+    + .form-control-hint {
+      margin-top: $space-base;
+    }
+  }
 }

--- a/src/django/users/serializers.py
+++ b/src/django/users/serializers.py
@@ -93,6 +93,8 @@ class OrganizationSerializer(serializers.ModelSerializer):
                                                   slug_field='weather_event_id')
     invites = serializers.ListField(child=serializers.EmailField(), write_only=True, required=False)
 
+    users = serializers.SlugRelatedField(many=True, read_only=True, slug_field='email')
+
     def validate_location(self, location_data):
         if 'api_city_id' not in location_data:
             raise serializers.ValidationError("Location ID is required.")
@@ -184,7 +186,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
         fields = ('id', 'created_at', 'name', 'location', 'units', 'invites',
                   'subscription', 'subscription_end_date', 'subscription_pending',
                   'plan_due_date', 'plan_name', 'plan_hyperlink', 'plan_setup_complete',
-                  'community_systems', 'weather_events',)
+                  'community_systems', 'weather_events', 'users',)
         read_only_fields = ('subscription_end_date', 'subscription_pending',)
 
 


### PR DESCRIPTION
## Overview

Hides the remove button for now with a note to contact support for help removing users, until we can implement a self-service method for removing users from an organization.

### Demo

![localhost-4210-settings](https://user-images.githubusercontent.com/4432106/38267464-9c5b1a06-3749-11e8-9048-564d74d548a2.png)

## Testing Instructions

 * `scripts/server`

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Connects to #850
