### PR TITLE
Fix password similarity validation

### DIFF
--- a/src/angular/planit/src/app/shared/password-validator/password-validator.directive.spec.ts
+++ b/src/angular/planit/src/app/shared/password-validator/password-validator.directive.spec.ts
@@ -23,9 +23,27 @@ describe('PasswordValidatorDirective', () => {
     });
   });
 
-  it('should disallow passwords similar to user attributes', () => {
-    directive.disallowed = ['Alexander'];
-    expect(directive.validate(new FormControl('alexander'))).toEqual({'similar': true});
+  describe('similar passwords', () => {
+    beforeEach(() => {
+      directive.disallowed = ['testclient@example.com', 'Test', 'Client'];
+    });
+
+    it('should disallow passwords similar to parts of user attributes', () => {
+      expect(directive.validate(new FormControl('example.com'))).toEqual({'similar': true});
+      expect(directive.validate(new FormControl('testclien'))).toEqual({'similar': true});
+    });
+
+    it('should disallow passwords similar to entirety of any user attributes', () => {
+      expect(directive.validate(new FormControl('estclient@example.co'))).toEqual({
+        'similar': true
+      });
+    });
+
+    it('should disallow passwords that exactly match any user attributes', () => {
+      expect(directive.validate(new FormControl('testclient@example.com'))).toEqual({
+        'similar': true
+      });
+    });
   });
 
   it('should disallow common passwords', () => {

--- a/src/angular/planit/src/app/shared/password-validator/password-validator.directive.ts
+++ b/src/angular/planit/src/app/shared/password-validator/password-validator.directive.ts
@@ -33,8 +33,8 @@ export class PasswordValidatorDirective implements Validator {
         if (!disallowedVal) {
           return true;
         }
-        const parts = disallowedVal.split(/\W+/);
-        parts.concat(disallowedVal);
+        let parts = disallowedVal.split(/\W+/);
+        parts = parts.concat(disallowedVal);
         return parts.every(part => {
           const matcher = new SequenceMatcher(null,
             part.toLowerCase(), control.value.toLowerCase());


### PR DESCRIPTION
## Overview

Fix password similarity validation.
We weren't comparing against full email addresses, just the parts of the email address.

### Demo

![screenshot from 2018-04-03 14-57-06](https://user-images.githubusercontent.com/4432106/38269737-5514b43a-374f-11e8-9b12-cccc9e450a85.png)


### Notes

For completeness I compared our test suite against the Django test suite for `UserAttributeSimilarityValidator` https://github.com/django/django/blob/master/tests/auth_tests/test_validators.py#L108-L170 and added a few tests for things we weren't covering.


## Testing Instructions

 * `scripts/server`

 - ~[ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.~

Closes #1042
