### PR TITLE
Look for location in Missy's Cities file before geocoding

### DIFF
--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -9,6 +9,7 @@ django-dbes==0.1.0
 django-debug-toolbar==1.9.1
 django-extensions==2.0.0
 django-premailer==0.2.0
+django-queryset-csv==1.0.0
 django-registration==2.4.1
 django-rest-auth==0.9.3
 django-watchman>=0.12,<0.12.99
@@ -16,7 +17,6 @@ factory-boy==2.10.0
 flake8==3.5.0
 ipdb==0.11
 ipython==6.2.1
+python-omgeo==5.0.0
 requests>=2.18,<2.19.99
 rollbar>=0.13,<0.13.99
-django-queryset-csv==1.0.0
-geopy==1.11.0


### PR DESCRIPTION
## Overview

Since the cities in Missy's data don't change much and we want to be able to re-run the ingest when we change them, this makes the location/org creation step look for saved lon/lat values in the cities.csv file. If no value is found, it falls back to geocoding as before.

I didn't change the geocoder, just added the coordinates it was producing to the spreadsheet, by hand.  As @maurizi points out, as of a few hours ago we could switch to OMGeo.  That would be relatively simple, but not as simple as leaving things as-is...

### Notes

Incidental changes:
- I got rid of all the row index lookups, instead unpacking each row into variables at the top of the loops.  For readability, and to add `strip()`, since there was one mis-match in city names due to a trailing space.
- I changed the `PlanItLocation` `get_or_create(name, is_coastal, point)` to an `update_or_create(name, is_coastal, defaults={point})` so that if we did change the geocoder and the coordinates changed (as is likely, since these are city/county/region centroids) it would move the `PlanItLocation` rather than making a new copy.
- I uploaded the new cities file with the lon/lat columns to S3. I first copied the old one to `missy_cities-without_lonlat.csv` so it wouldn't be lost.  We should probably delete it later for tidiness.

## Testing Instructions

- In the VM, run `./scripts/ingest_missy_dataset`.  It should complete, printing "Creating organizations" then a bunch of "Processing risks and actions for [city]" lines (less than before, though.)
- Running it again should also work, this time ending with "Ingest complete. Imported 0 organizations and 0 actions", since it didn't create any items (though doesn't say one way or the other if it applied updates to existing items).
- I'm not entirely clear on how to selectively reset the state of the database to simulate a fresh run of this, since as I understand it many of the objects it creates are not marked in any way that distinguishes them from instances created through other means.

(not added to CHANGELOG)

Closes #875.