### PR TITLE
Do not propagate CCAPI proxy Unauthorized error to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Preload static indicator chart configuration data on app load
 - Use stored coordinates and switch geocoders in `ingest_missy_dataset`
 - Change cyclone and tropical storms to coastal_only
+- Do not log users out if Temperate's Climate API token is invalid
 
 ## [1.0.0] - 2018-04-03
 - MVP Release


### PR DESCRIPTION
## Overview
Communication between Angular and Django is handled by the `PlanItApiHttp` service, which performs routine tasks like including the user's API token, as well as checking the response status code for a code that indicates the user's session has become invalid. If the Temperate API sends back a 401 Unauthorized or 403 Forbidden error, it triggers the invalid session logic, logs the user out, and brings the user to the home screen.

In some cases, the Climate API key that Temperate uses to communicate with the Climate API can become invalid (For example, if it is reset remotely or as a race condition while `refresh_token` is running). This would cause Temperate to receive a 401 Unauthorized error, which it would send back to the user, causing the user to become logged out.

This change checks for 401 and 403 errors in the API proxy response, and if we get one sends a generic server error instead.

## Testing Instructions
- Log into the Climate API instance that your Temperate environment is configured to use
- In the "Your Profile" page, click "Get New API Token"
- Return to Temperate and use the application
  - You should not be logged out

 - [ ] Is the "[Unreleased]" section of the CHANGELOG.md updated with any changes that might complicate the next release? Consider adding links to any related PRs if additional context is required, but avoid only including the link in the CHANGELOG, with no additional description.

Closes #852 