### PR TITLE
Add comparison links to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+<!--When making a new release, remember to update the magic links at the bottom.-->
+
 ## [Unreleased]
 - Preload static indicator chart configuration data on app load
 
@@ -66,6 +68,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - App now hosted at https://temperate.io instead of https://app.temperate.io
 - Production application no longer restricted to use on Azavea VPN
 
-## [0.1.0] - 2018-03-08
+## 0.1.0 - 2018-03-08
 ### Added
 - Initial release
+
+[Unreleased]: https://github.com/azavea/temperate/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/azavea/temperate/compare/0.1.5...1.0.0
+[0.1.5]: https://github.com/azavea/temperate/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/azavea/temperate/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/azavea/temperate/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/azavea/temperate/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/azavea/temperate/compare/0.1.0...0.1.1


### PR DESCRIPTION
## Overview

Adds the magic link definitions to turn the release tag headers in the CHANGELOG into comparison links.  As in the canonical "Keep a Changelog" changelog, they're at the bottom because otherwise they would hurt plaintext readability.

### Demo

![image](https://user-images.githubusercontent.com/6598836/38377392-d58346de-38c8-11e8-8ae6-96fb45be45d2.png)

### Notes

I discovered when doing this for Cicero that putting html-style comments in Markdown makes them not show up in the rendered version on GitHub, so I added a comment like that at the top so that people editing the file will be reminded to keep the links up to date.

## Testing Instructions

Have a look at https://github.com/azavea/temperate/blob/feature/kjh/add-links-to-changelog/CHANGELOG.md and try out the newly linkified version headers.
