### PR TITLE
Convert cyclones and other large oceanic storms to coastal_only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Preload static indicator chart configuration data on app load
 - Use stored coordinates and switch geocoders in `ingest_missy_dataset`
+- Change cyclone and tropical storms to coastal_only
 
 ## [1.0.0] - 2018-04-03
 - MVP Release

--- a/src/django/planit_data/fixtures/weatherevents.json
+++ b/src/django/planit_data/fixtures/weatherevents.json
@@ -159,7 +159,7 @@
     "pk": 8,
     "fields": {
         "name": "Cyclone (Hurricane / Typhoon)",
-        "coastal_only": false,
+        "coastal_only": true,
         "concern": null,
         "display_class": "icon-hurricane",
         "description": "Large storm systems capable of prolonged destructive winds over a large area and exceptional precipitation amounts",
@@ -545,7 +545,7 @@
     "pk": 31,
     "fields": {
         "name": "Tropical storm",
-        "coastal_only": false,
+        "coastal_only": true,
         "concern": null,
         "display_class": "icon-tropical-storm",
         "description": "Large storm systems created by convective heat originiating in tropical latitudes",


### PR DESCRIPTION
## Overview
Because we currently don't have a mechanism to differentiate directly coastal concerns such as sea level rise from non-coastal areas with "coastal proximity", we currently over-prescribe "coastal proximity" events like hurricanes as suggested hazards. This changes those hazards to be coastal-only, potentially under-prescribing them as suggested hazards for certain locations like Philadelphia, but it is expected this will result in a generally superior suggestion.

## Testing Instructions
- Import the fixtures
- Cyclone, tropical storm, and extra tropical storm should be marked as "coastal only" and suggested only for is_coastal locations within the appropriate georegion.

 - [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1087 
