### PR TITLE
Redirect to subscription page when no plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!--When making a new release, remember to update the magic links at the bottom.-->
 
 ## [Unreleased]
+### Fixed
+ - Redirect users without a plan and an expired subscription to the subscription page
 
 ## [1.5.0] - 2018-09-14
 ### Added

--- a/src/angular/planit/src/app/core/services/expiration-guard.service.ts
+++ b/src/angular/planit/src/app/core/services/expiration-guard.service.ts
@@ -22,7 +22,7 @@ export class ExpirationGuard implements CanActivate {
       return this.userService.current().map(user => {
         if (user.primary_organization) {
           const org = new Organization(user.primary_organization);
-          if (org.isExpired()) {
+          if (org.isExpired() && org.hasPlan()) {
             if (route.url[0].path !== 'expired') {
               this.router.navigate(['/expired']);
               return false;

--- a/src/angular/planit/src/app/core/services/plan-auth-guard.service.ts
+++ b/src/angular/planit/src/app/core/services/plan-auth-guard.service.ts
@@ -31,8 +31,13 @@ export class PlanAuthGuard implements CanActivate {
             return true;
           } else if (route.url[0].path !== 'plan' && route.url[0].path !== 'settings' &&
                      route.url[0].path !== 'subscription') {
-            // direct user to create organization plan, if one not set up yet
-            this.router.navigate(['/plan']);
+            if (org.isExpired()) {
+              // direct user with expired subscription and no plan set up to subscription page
+              this.router.navigate(['/subscription']);
+            } else {
+              // direct user to create organization plan, if one not set up yet
+              this.router.navigate(['/plan']);
+            }
             return false;
           } else {
             return true;


### PR DESCRIPTION
## Overview

Fixes infinite redirect for users with no organization plan on their primary organization, and an
expired subscription.


### Notes

Did not attempt to otherwise refactor the interactions here between the routing rules in `plan-auth-guard` and `expiration-guard`, which were conflicting in this case.


## Testing Instructions

 * Create an organization with an expired subscription and no plan
 * Assign it as the primary organization as a user
 * Log in as the user
 * Should be redirected to `/subscription` with no infinite redirect
 * Routing should otherwise continue to function as before

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Fixes #1149.
