### PR TITLE
Allow existing users to be invited to orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Added ability to remove users from an organization to the settings page
 ### Fixed
  - Fixed bug where organization dropdown could be shown to a user with no organizations
+ - Fixed a bug where users can invite the same user to their organization twice.
+### Changed
+ - Existing users can now be invited to new and existing organizations.
 
 ## [1.7.0] - 2019-02-16
 ### Changed

--- a/src/angular/planit/src/app/shared/user-emails/user-emails.component.html
+++ b/src/angular/planit/src/app/shared/user-emails/user-emails.component.html
@@ -9,12 +9,16 @@
          [(ngModel)]="email">
   <!-- Validation tooltip on <span> because tooltips don't show on a disabled button -->
   <span class="input-group-btn"
-        tooltip="Please enter a valid email address"
+        [tooltip]="emails.has(email) ? 'This user already exists' : 'Please enter a valid email address'"
         placement="top"
         container="body"
-        [isDisabled]="email.length > 0 && emailControl.valid">
-    <button class="button button-primary button-icon" type="button" (click)="add()"
-            [disabled]="email.length == 0 || emailControl.invalid" [tabindex]="tabindex">
+        [isDisabled]="email.length > 0 && emailControl.valid && !emails.has(email)">
+    <button
+        class="button button-primary button-icon"
+        type="button"
+        (click)="add()"
+        [disabled]="email.length == 0 || emailControl.invalid || emails.has(email)"
+        [tabindex]="tabindex">
       <i class="icon-plus"></i>
     </button>
   </span>

--- a/src/django/users/templates/registration/existing_user_invitation_email.html
+++ b/src/django/users/templates/registration/existing_user_invitation_email.html
@@ -1,0 +1,16 @@
+{% load premailer %}
+{% premailer %}
+<html>
+    <p>Hello there!</p>
+    <p>You’ve been invited to join an organization on <a href="https://temperate.io">Temperate</a>, your city’s climate adaptation planning companion.</p>
+
+    <p>
+        <strong>Organization:</strong> {{ organization.name }}
+        <br/>
+        <strong>Location:</strong> {{ organization.location }}
+    </p>
+
+    <p>Log in to Temperate via the link below to view or change this organization's plan.</p>
+    <p><a href="{{ login_url }}">Log in to Temperate</a>
+</html>
+{% endpremailer %}

--- a/src/django/users/templates/registration/existing_user_invitation_email.txt
+++ b/src/django/users/templates/registration/existing_user_invitation_email.txt
@@ -1,0 +1,13 @@
+Hello there!
+
+You’ve been invited to join an organization on Temperate, your city’s climate adaptation planning companion.
+
+Organization: {{ organization.name }}
+Location: {{ organization.location }}
+
+Log in to Temperate at the link below to view or change this organization's plan.
+
+{{ login_url }}
+
+
+Learn more about Temperate at https://temperate.io

--- a/src/django/users/templates/registration/existing_user_invitation_email_subject.txt
+++ b/src/django/users/templates/registration/existing_user_invitation_email_subject.txt
@@ -1,0 +1,1 @@
+An invitation to join an organization on Temperate, your city’s climate adaptation planning companion

--- a/src/django/users/tests/test_models.py
+++ b/src/django/users/tests/test_models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from users.models import PlanItLocation, PlanItOrganization, PlanItUser
 from planit_data.models import GeoRegion, OrganizationWeatherEvent, WeatherEvent, WeatherEventRank
 from planit_data.tests.factories import GeoRegionFactory
+from users.tests.factories import OrganizationFactory, UserFactory
 
 
 class OrganizationTestCase(TestCase):
@@ -273,7 +274,7 @@ class LocationManagerTestCase(TestCase):
 
 class PlanItUserTestCase(TestCase):
     def test_default_user_model(self):
-        """Ensure PlanItUser is the default user models
+        """Ensure PlanItUser is the default user model.
 
         `./manage.py createsuperuser` uses get_user_model to determine what class to invoke
         create_superuser on, this ensures the command will be directed to the correct class.
@@ -313,3 +314,66 @@ class PlanItUserTestCase(TestCase):
         self.assertEqual(0, user.organizations.all().count(), 'User should have no organizations')
         self.assertEqual(user.primary_organization, None,
                          'User should have no primary organization')
+
+    def test_add_user_via_email_no_org(self):
+        """Ensure that adding a user via email properly sets the organization."""
+        org = OrganizationFactory()
+        existing_user_no_org_email = 'existinguser@local.gov'
+        user = UserFactory(email=existing_user_no_org_email)
+        # The factory constructs the user with a new Organization by default, which is normally okay
+        # but in this case we don't want that, so clear it out.
+        user.organizations.clear()
+        user.primary_organization = None
+        user.save()
+        # Adding a user that has no org should update their primary_organization
+        self.assertIsNone(user.primary_organization)
+        new_user, created, added = PlanItUser.objects.add_via_email_to_organization(
+            existing_user_no_org_email, org
+        )
+        self.assertEqual(new_user, user)
+        self.assertFalse(created)
+        self.assertTrue(added)
+        self.assertEqual(new_user.primary_organization, org)
+        self.assertIn(org, new_user.organizations.all())
+
+    def test_add_user_via_email_same_org(self):
+        """Ensure that adding a user that has an org to that same org does nothing."""
+        org = OrganizationFactory()
+        existing_user_org_email = 'existinguser+org1@local.gov'
+        user = UserFactory(email=existing_user_org_email, primary_organization=org)
+        new_user, created, added = PlanItUser.objects.add_via_email_to_organization(
+            existing_user_org_email, org
+        )
+        self.assertEqual(new_user, user)
+        self.assertFalse(created)
+        self.assertFalse(added)
+
+    def test_add_user_via_email_different_org(self):
+        """Ensure that adding a user that has an org adds the org to that user's organizations."""
+        org1 = OrganizationFactory()
+        org2 = OrganizationFactory()
+        existing_user_org1_email = 'existinguser+org1@local.gov'
+        user = UserFactory(email=existing_user_org1_email, primary_organization=org1)
+        self.assertEqual(user.primary_organization, org1)
+        new_user, created, added = PlanItUser.objects.add_via_email_to_organization(
+            existing_user_org1_email, org2
+        )
+        self.assertEqual(new_user, user)
+        self.assertEqual(new_user.primary_organization, org1)
+        self.assertFalse(created)
+        self.assertTrue(added)
+        self.assertIn(org2, new_user.organizations.all())
+
+    def test_add_user_via_email_new_user(self):
+        """Ensure that adding a user that doesn't exist creates them in the correct organization."""
+        org = OrganizationFactory()
+        new_user_email = 'newuser@local.gov'
+        self.assertEqual(PlanItUser.objects.all().count(), 0)
+        new_user, created, added = PlanItUser.objects.add_via_email_to_organization(
+            new_user_email, org
+        )
+        self.assertEqual(PlanItUser.objects.all().count(), 1)
+        self.assertTrue(created)
+        self.assertFalse(added)
+        self.assertEqual(new_user.primary_organization, org)
+        self.assertIn(org, new_user.organizations.all())


### PR DESCRIPTION
## Overview

Allows inviting existing users to organizations.

### Notes

I added some new email templates as part of this; @jcahail or @alexelash do you have any suggestions about the wording? These templates will be sent out when an existing Temperate user is invited to an organization that they're not already a part of.

## Testing Instructions

 * Follow the sign-up workflow through to the invitations screen. There, add invitations for 1) an existing Temperate user 2) An email with no Temperate user. Click the button to send invitations and confirm that:
    * It works
    * The users receive different types of emails
    * Links and organization information in both emails are correct.
 * On the account settings page, send invitations to 1) an existing Temperate user 2) An email with no Temperate user. Confirm the same items as for the previous step.
 * Run `./scripts/test` and confirm tests and linting are happy.

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1192 
Closes #794