### PR TITLE
Prevent creating duplicate organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - Fixed bug where organization dropdown could be shown to a user with no organizations
  - Fixed a bug where users can invite the same user to their organization twice.
+ - Fixed a bug where users could accidentally create duplicate organizations
 ### Changed
  - Existing users can now be invited to new and existing organizations.
 

--- a/src/angular/planit/src/app/organization-wizard/steps/invite-step/invite-step.component.html
+++ b/src/angular/planit/src/app/organization-wizard/steps/invite-step/invite-step.component.html
@@ -26,6 +26,7 @@
   <div class="step-footer-navigation">
     <button type="button"
             class="button button-primary"
+            [disabled]="requestPending"
             (click)="confirm()">
       <span *ngIf="!shouldSkip()">
         Send {{ form.controls.invites.value.length }}

--- a/src/angular/planit/src/app/organization-wizard/steps/invite-step/invite-step.component.ts
+++ b/src/angular/planit/src/app/organization-wizard/steps/invite-step/invite-step.component.ts
@@ -24,6 +24,7 @@ export class InviteStepComponent extends OrganizationWizardStepComponent<InviteS
 
   public key: OrganizationStepKey = OrganizationStepKey.Invite;
   public inviteErrors: { [key: string]: string} = {};
+  public requestPending = false;
 
   @Input() form: FormGroup;
   @Input() wizard: WizardComponent;
@@ -68,10 +69,14 @@ export class InviteStepComponent extends OrganizationWizardStepComponent<InviteS
   }
 
   confirm() {
+    this.requestPending = true;
+
     this.save(undefined).then((success) => {
       if (success) {
         this.router.navigate(['/plan']);
       } else {
+        this.requestPending = false;
+
         const controls = this.form.controls;
         if (controls.location.invalid || controls.name.invalid) {
           this.wizard.navigation.goToStep(0);


### PR DESCRIPTION
## Overview

This PR disables the submit button during the organization creation wizard while the API call is pending, helping to prevent accidentally creating duplicate organizations due to double-clicking on the submission button.

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

As noted in https://github.com/azavea/temperate/issues/1141#issuecomment-478053566 this doesn't appear to be the _only_ way for duplicate organizations/locations can be created, but it is the only one we know of at the moment, and this is a problem worth fixing for it's own sake.

## Testing Instructions

 * On the `develop` branch, you should be able to create duplicate organization(s) by rapidly clicking on the "Send invites and finish" button. Note that the organizations created in this way will be in a broken state and will need to be deleted.
 * On this branch, no matter the number of clicks, only 1 API call should occur and no duplicate organizations should be created.

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1208
