### PR TITLE
Add climate data models to Area Indicators datamodel project

### DIFF
--- a/src/area-indicators/build.sbt
+++ b/src/area-indicators/build.sbt
@@ -124,6 +124,7 @@ lazy val datamodelDependencies = commonDependencies ++ Seq(
   Dependencies.geotrellisS3,
   Dependencies.geotrellisSpark,
   Dependencies.geotrellisVector,
+  Dependencies.sealerate,
   Dependencies.sparkCore
 )
 lazy val datamodel = (project in file("datamodel"))

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/ClimateModel.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/ClimateModel.scala
@@ -1,0 +1,47 @@
+package io.temperate.datamodel
+
+import ca.mrvisser.sealerate
+
+sealed trait ClimateModel {
+  def name: String
+}
+
+object ClimateModel {
+  case object Access10     extends ClimateModel { val name = "ACCESS1-0"       }
+  case object Access13     extends ClimateModel { val name = "ACCESS1-3"       }
+  case object BccCsm11     extends ClimateModel { val name = "bcc-csm1-1"      }
+  case object BccCsm11M    extends ClimateModel { val name = "bcc-csm1-1-m"    }
+  case object BnuEsm       extends ClimateModel { val name = "BNU-ESM"         }
+  case object CanEsm2      extends ClimateModel { val name = "CanESM2"         }
+  case object Ccsm4        extends ClimateModel { val name = "CCSM4"           }
+  case object Cesm1Bgc     extends ClimateModel { val name = "CESM1-BGC"       }
+  case object Cesm1Cam5    extends ClimateModel { val name = "CESM1-CAM5"      }
+  case object CmccCm       extends ClimateModel { val name = "CMCC-CM"         }
+  case object CmccCms      extends ClimateModel { val name = "CMCC-CMS"        }
+  case object CnrmCm5      extends ClimateModel { val name = "CNRM-CM5"        }
+  case object CsiroMk360   extends ClimateModel { val name = "CSIRO-Mk3-6-0"   }
+  case object EcEarth      extends ClimateModel { val name = "EC-EARTH"        }
+  case object FGoalsG2     extends ClimateModel { val name = "FGOALS-g2"       }
+  case object GfdlCm3      extends ClimateModel { val name = "GFDL-CM3"        }
+  case object GfdlEsm2G    extends ClimateModel { val name = "GFDL-ESM2G"      }
+  case object GfdlEsm2M    extends ClimateModel { val name = "GFDL-ESM2M"      }
+  case object GissE2H      extends ClimateModel { val name = "GISS-E2-H"       }
+  case object GissE2R      extends ClimateModel { val name = "GISS-E2-R"       }
+  case object HadGem2Ao    extends ClimateModel { val name = "HadGEM2-AO"      }
+  case object HadGem2Cc    extends ClimateModel { val name = "HadGEM2-CC"      }
+  case object HadGem2Es    extends ClimateModel { val name = "HadGEM2-ES"      }
+  case object Inmcm4       extends ClimateModel { val name = "inmcm4"          }
+  case object IpslCm5ALr   extends ClimateModel { val name = "IPSL-CM5A-LR"    }
+  case object IpslCm5AMr   extends ClimateModel { val name = "IPSL-CM5A-MR"    }
+  case object Miroc5       extends ClimateModel { val name = "MIROC5"          }
+  case object MirocEsm     extends ClimateModel { val name = "MIROC5-ESM"      }
+  case object MirocEsmChem extends ClimateModel { val name = "MIROC5-ESM-CHEM" }
+  case object MpiEsmLr     extends ClimateModel { val name = "MPI-ESM-LR"      }
+  case object MpiEsmMr     extends ClimateModel { val name = "MPI-ESM-MR"      }
+  case object MriCgcm3     extends ClimateModel { val name = "MRI-CGCM3"       }
+  case object NorEsm1M     extends ClimateModel { val name = "NorESM1-M"       }
+
+  def unapply(str: String): Option[ClimateModel] = options.find(_.name == str)
+
+  val options: Set[ClimateModel] = sealerate.values[ClimateModel]
+}

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Dataset.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Dataset.scala
@@ -1,0 +1,100 @@
+package io.temperate.datamodel
+
+import java.net.URI
+
+import ca.mrvisser.sealerate
+import io.temperate.datamodel.ClimateModel._
+
+sealed trait Dataset {
+  def name: String
+  def resolution: Double
+
+  def models: Set[ClimateModel]
+
+  def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI
+}
+
+object Dataset {
+  case object Loca extends Dataset {
+    val name: String       = "LOCA"
+    val resolution: Double = 0.0625
+
+    val models = Set[ClimateModel](
+      Access10,
+      Access13,
+      BccCsm11,
+      BccCsm11M,
+      CanEsm2,
+      Ccsm4,
+      Cesm1Bgc,
+      Cesm1Cam5,
+      CmccCm,
+      CmccCms,
+      CnrmCm5,
+      CsiroMk360,
+      EcEarth,
+      FGoalsG2,
+      GfdlCm3,
+      GfdlEsm2G,
+      GfdlEsm2M,
+      GissE2H,
+      GissE2R,
+      HadGem2Ao,
+      HadGem2Cc,
+      HadGem2Es,
+      Inmcm4,
+      IpslCm5ALr,
+      IpslCm5AMr,
+      Miroc5,
+      MirocEsm,
+      MirocEsmChem,
+      MpiEsmLr,
+      MpiEsmMr,
+      MriCgcm3,
+      NorEsm1M
+    )
+
+    def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI = {
+      val scenarioName = scenario.name.toLowerCase
+      val variableName = variable.name.toLowerCase
+      URI.create(
+        s"https://nasanex.s3.amazonaws.com/LOCA/${model}/16th/${scenarioName}/r6i1p1/${variableName}/${variableName}_day_${model}_${scenarioName}_r6i1p1_${year}0101-${year}1231.LOCA_2016-04-02.16th.nc")
+    }
+  }
+
+  case object NexGddp extends Dataset {
+    val name: String       = "nex-gddp"
+    val resolution: Double = 0.25
+
+    val models = Set[ClimateModel](
+      Access10,
+      BccCsm11,
+      BnuEsm,
+      CanEsm2,
+      Ccsm4,
+      Cesm1Bgc,
+      CnrmCm5,
+      CsiroMk360,
+      GfdlCm3,
+      GfdlEsm2G,
+      GfdlEsm2M,
+      Inmcm4,
+      IpslCm5ALr,
+      IpslCm5AMr,
+      Miroc5,
+      MirocEsm,
+      MirocEsmChem,
+      MpiEsmLr,
+      MpiEsmMr,
+      MriCgcm3,
+      NorEsm1M
+    )
+
+    def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI =
+      ???
+  }
+
+  def unapply(str: String): Option[Dataset] = options.find(_.name == str)
+
+  val options: Set[Dataset] = sealerate.values[Dataset]
+}

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Indicator.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Indicator.scala
@@ -1,28 +1,27 @@
 package io.temperate.datamodel
 
+import ca.mrvisser.sealerate
 import io.temperate.datamodel.Operations.TimedDictionary
 
-trait BoxOperation {
+sealed trait Indicator {
+  def name: String
+
   def box: Seq[TimedDictionary] => Seq[Double]
-}
-
-sealed abstract class Indicator(name: String) extends BoxOperation {}
-
-case object AverageHighTemperature extends Indicator("average-high-temperature") {
-  def box = Boxes.average((_) => true, Variable.TasMax.toString)
-}
-
-case object AverageLowTemperature extends Indicator("average-low-temperature") {
-  def box = Boxes.average((_) => true, Variable.TasMin.toString)
 }
 
 object Indicator {
 
-  def unapply(str: String): Option[Indicator] = {
-    str.trim.toLowerCase match {
-      case "average-high-temperature" => Some(AverageHighTemperature)
-      case "average-low-temperature"  => Some(AverageLowTemperature)
-      case _                          => None
-    }
+  case object AverageHighTemperature extends Indicator {
+    val name = "average-high-temperature"
+    def box  = Boxes.average((_) => true, Variable.TasMax.name)
   }
+
+  case object AverageLowTemperature extends Indicator {
+    val name = "average-low-temperature"
+    def box  = Boxes.average((_) => true, Variable.TasMin.name)
+  }
+
+  def unapply(str: String): Option[Indicator] = Indicator.options.find(_.name == str)
+
+  val options: Set[Indicator] = sealerate.values[Indicator]
 }

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Scenario.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Scenario.scala
@@ -1,19 +1,37 @@
 package io.temperate.datamodel
 
-sealed abstract class Scenario(name: String, label: String, description: String, alias: String) {}
+import ca.mrvisser.sealerate
 
-case object RCP45      extends Scenario("rcp45", "RCP 4.5", "", "Low emissions")
-case object RCP85      extends Scenario("rcp85", "RCP 8.5", "", "High emissions")
-case object Historical extends Scenario("historical", "Historical", "", "")
+sealed trait Scenario {
+  def name: String
+  def label: String
+  def description: String
+  def alias: String
+}
 
 object Scenario {
-
-  def unapply(str: String): Option[Scenario] = {
-    str.trim.toLowerCase match {
-      case "rcp45"      => Some(RCP45)
-      case "rcp85"      => Some(RCP85)
-      case "historical" => Some(Historical)
-      case _            => None
-    }
+  case object RCP45 extends Scenario {
+    val name        = "rcp45"
+    val label       = "RCP 4.5"
+    val description = ""
+    val alias       = "Low emissions"
   }
+
+  case object RCP85 extends Scenario {
+    val name        = "rcp85"
+    val label       = "RCP 8.5"
+    val description = ""
+    val alias       = "High emissions"
+  }
+
+  case object Historical extends Scenario {
+    val name        = "historical"
+    val label       = "Historical"
+    val description = ""
+    val alias       = ""
+  }
+
+  def unapply(str: String): Option[Scenario] = Scenario.options.find(_.name == str)
+
+  val options: Set[Scenario] = sealerate.values[Scenario]
 }

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Variable.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Variable.scala
@@ -1,11 +1,33 @@
 package io.temperate.datamodel
 
-object Variable extends Enumeration {
-  val TasMax = Value("tasmax")
-  val TasMin = Value("tasmin")
-  val Precip = Value("pr")
+import ca.mrvisser.sealerate
 
-  def unapply(str: String): Option[Value] = {
-    values.find(_.toString == str)
+sealed trait Variable {
+  def name: String
+  def unit: String
+  def label: String
+}
+
+object Variable {
+  case object TasMax extends Variable {
+    val name  = "tasmax"
+    val unit  = "K"
+    val label = "Daily Mean of the Daily Max Near-Surface Air Temperature"
   }
+
+  case object TasMin extends Variable {
+    val name  = "tasmin"
+    val unit  = "K"
+    val label = "Daily Mean of the Daily Min Near-Surface Air Temperature"
+  }
+
+  case object Precip extends Variable {
+    val name  = "pr"
+    val unit  = "kg*m^-2*s^-2"
+    val label = "Daily Mean Precipitation at Surface"
+  }
+
+  def unapply(str: String): Option[Variable] = options.find(_.name == str)
+
+  val options: Set[Variable] = sealerate.values[Variable]
 }

--- a/src/area-indicators/ingest/src/main/scala/Main.scala
+++ b/src/area-indicators/ingest/src/main/scala/Main.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import com.monovore.decline._
 import org.apache.spark._
 
-object HelloWorld
+object Main
     extends CommandApp(
       name = "area-indicators-ingest",
       header = "Copy NetCDF Climate Data to GeoTrellis Avro Layers for Area Indicators API",

--- a/src/area-indicators/project/Dependencies.scala
+++ b/src/area-indicators/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Versions {
   val Http4sVersion            = "0.20.3"
   val LogbackVersion           = "1.2.3"
   val ScapegoatVersion         = "1.3.8"
+  val SealerateVersion         = "0.0.5"
   val SparkVersion             = "2.4.1"
   val Specs2Version            = "4.1.0"
 }
@@ -30,6 +31,7 @@ object Dependencies {
   val http4sServer          = "org.http4s"                  %% "http4s-blaze-server"     % Versions.Http4sVersion
   val http4sDsl             = "org.http4s"                  %% "http4s-dsl"              % Versions.Http4sVersion
   val logbackClassic        = "ch.qos.logback"              % "logback-classic"          % Versions.LogbackVersion
+  val sealerate             = "ca.mrvisser"                 %% "sealerate"               % Versions.SealerateVersion
   val sparkCore             = "org.apache.spark"            %% "spark-core"              % Versions.SparkVersion % "provided"
   val specs2Core            = "org.specs2"                  %% "specs2-core"             % Versions.Specs2Version % "test"
 }


### PR DESCRIPTION
## Overview

Adds climate data models based on a discussion with @maurizi  and @pomadchin earlier today. This PR is happening now because these models will be required for parallel work being done soon by myself and @maurizi.

I found an up to date library that provides the macro discussed to automatically construct the `options` Set for each type. Whoop. 

### Demo

N/A.

## Notes

This also sneaks in the latest version of geotrellis-contrib to the ingest subproject but its not used anywhere yet. `./sbt ingest/compile` should pull down the dependency and succeed, but its not useful anywhere. TBH, I was just too lazy to cherry pick the model changes off the top of the branch I was working on the ingest in.

## Testing Instructions

 `./sbt api/compile` should succeed and `./sbt api/run` should continue to start the server and serve broken requests at the indicator endpoint.

Connects #1239 
Connects #1240 
