### PR TITLE
Bump to tag in hseeberger registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,4 +102,4 @@ services:
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/area-indicators/
-    entrypoint: sbt
+    entrypoint: ./sbt


### PR DESCRIPTION
## Overview

Looks like the tag we were using went missing? No local error since I would have had the old tag downloaded already.

Hopefully this fixes the ci build once the other issues are resolved. 