### PR TITLE
Refactor sbt-lighter S3 destinations

### DIFF
--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -2,3 +2,8 @@ resource "aws_s3_bucket" "logs" {
   bucket = "${lower(var.environment)}-${var.aws_region}-climate-planit-logs"
   acl    = "private"
 }
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = "${lower(var.environment)}-${var.aws_region}-climate-planit-artifacts"
+  acl    = "private"
+}

--- a/src/area-indicators/build.sbt
+++ b/src/area-indicators/build.sbt
@@ -1,4 +1,5 @@
 import sbtlighter._
+import com.amazonaws.services.s3.model.ObjectMetadata
 
 cancelable in Global := true
 
@@ -35,8 +36,8 @@ lazy val commonSettings = Seq(
     "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots"
   ),
 
-  // SBT Lighter -- Easiest way to configure the plugin is globally for the entire project
-  //  even though it's just used in `ingest`.
+  // SBT Lighter -- Easiest way to configure the plugin is globally for the
+  // entire project even though it's just used in `ingest`.
   sparkAwsRegion := "us-east-1",
   sparkClusterName := s"area-indicators-ingest-${environment}",
   sparkCoreEbsSize := None,
@@ -50,8 +51,13 @@ lazy val commonSettings = Seq(
   sparkMasterType := "m5d.2xlarge",
   sparkInstanceCount := 3,
   sparkInstanceRole := "EMR_EC2_DefaultRole",
-  sparkS3JarFolder := s"s3://${environment}-us-east-1-climate-config-emr/jars/",
-  sparkS3LogUri := Some(s"s3://${environment}-us-east-1-climate-config-emr/logs/"),
+  sparkS3JarFolder := s"s3://${environment}-us-east-1-climate-planit-artifacts/area-indicators",
+  sparkS3LogUri := Some(s"s3://${environment}-us-east-1-climate-planit-logs/area-indicators"),
+  sparkS3PutObjectDecorator := { req =>
+    val metadata = new ObjectMetadata()
+    metadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION)
+    req.withMetadata(metadata)
+  },
   sparkEmrConfigs := List(
     EmrConfig("spark").withProperties(
       "maximizeResourceAllocation" -> "true"


### PR DESCRIPTION
## Overview

- Add `${environment}-${aws_region}-climate-planit-artifacts` bucket
- Add `sparkS3PutObjectDecorator` for object encryption
- Refactor `sparkS3JarFolder` and `sparkS3LogUri`

Closes #1241 

### Checklist

 - [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

## Testing Instructions

- See that the Terraform plan output is clean:
```bash
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-4.3# ./scripts/infra plan
...
No changes. Infrastructure is up-to-date.
```
- Follow the [Running the Ingest](https://github.com/azavea/temperate/tree/develop/src/area-indicators#running-the-ingest) instructions
- After the job completes, ensure that artifacts and logs are present in S3:
```bash
$ aws s3 ls s3://staging-us-east-1-climate-planit-artifacts/area-indicators/
2019-07-26 11:47:38  107391183 area-indicators-ingest-assembly.jar
$ aws s3 ls s3://staging-us-east-1-climate-planit-logs/area-indicators/
                           PRE j-1D7N232415GQ4/
```