### PR TITLE
Implement LOCA Ingest

### DIFF
--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/ClimateModel.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/ClimateModel.scala
@@ -15,39 +15,39 @@ sealed trait ClimateModel extends Ordered[ClimateModel] {
 }
 
 object ClimateModel {
-  case object Access10     extends ClimateModel { val name = "ACCESS1-0"       }
-  case object Access13     extends ClimateModel { val name = "ACCESS1-3"       }
-  case object BccCsm11     extends ClimateModel { val name = "bcc-csm1-1"      }
-  case object BccCsm11M    extends ClimateModel { val name = "bcc-csm1-1-m"    }
-  case object BnuEsm       extends ClimateModel { val name = "BNU-ESM"         }
-  case object CanEsm2      extends ClimateModel { val name = "CanESM2"         }
-  case object Ccsm4        extends ClimateModel { val name = "CCSM4"           }
-  case object Cesm1Bgc     extends ClimateModel { val name = "CESM1-BGC"       }
-  case object Cesm1Cam5    extends ClimateModel { val name = "CESM1-CAM5"      }
-  case object CmccCm       extends ClimateModel { val name = "CMCC-CM"         }
-  case object CmccCms      extends ClimateModel { val name = "CMCC-CMS"        }
-  case object CnrmCm5      extends ClimateModel { val name = "CNRM-CM5"        }
-  case object CsiroMk360   extends ClimateModel { val name = "CSIRO-Mk3-6-0"   }
-  case object EcEarth      extends ClimateModel { val name = "EC-EARTH"        }
-  case object FGoalsG2     extends ClimateModel { val name = "FGOALS-g2"       }
-  case object GfdlCm3      extends ClimateModel { val name = "GFDL-CM3"        }
-  case object GfdlEsm2G    extends ClimateModel { val name = "GFDL-ESM2G"      }
-  case object GfdlEsm2M    extends ClimateModel { val name = "GFDL-ESM2M"      }
-  case object GissE2H      extends ClimateModel { val name = "GISS-E2-H"       }
-  case object GissE2R      extends ClimateModel { val name = "GISS-E2-R"       }
-  case object HadGem2Ao    extends ClimateModel { val name = "HadGEM2-AO"      }
-  case object HadGem2Cc    extends ClimateModel { val name = "HadGEM2-CC"      }
-  case object HadGem2Es    extends ClimateModel { val name = "HadGEM2-ES"      }
-  case object Inmcm4       extends ClimateModel { val name = "inmcm4"          }
-  case object IpslCm5ALr   extends ClimateModel { val name = "IPSL-CM5A-LR"    }
-  case object IpslCm5AMr   extends ClimateModel { val name = "IPSL-CM5A-MR"    }
-  case object Miroc5       extends ClimateModel { val name = "MIROC5"          }
-  case object MirocEsm     extends ClimateModel { val name = "MIROC5-ESM"      }
-  case object MirocEsmChem extends ClimateModel { val name = "MIROC5-ESM-CHEM" }
-  case object MpiEsmLr     extends ClimateModel { val name = "MPI-ESM-LR"      }
-  case object MpiEsmMr     extends ClimateModel { val name = "MPI-ESM-MR"      }
-  case object MriCgcm3     extends ClimateModel { val name = "MRI-CGCM3"       }
-  case object NorEsm1M     extends ClimateModel { val name = "NorESM1-M"       }
+  case object Access10     extends ClimateModel { val name = "ACCESS1-0"      }
+  case object Access13     extends ClimateModel { val name = "ACCESS1-3"      }
+  case object BccCsm11     extends ClimateModel { val name = "bcc-csm1-1"     }
+  case object BccCsm11M    extends ClimateModel { val name = "bcc-csm1-1-m"   }
+  case object BnuEsm       extends ClimateModel { val name = "BNU-ESM"        }
+  case object CanEsm2      extends ClimateModel { val name = "CanESM2"        }
+  case object Ccsm4        extends ClimateModel { val name = "CCSM4"          }
+  case object Cesm1Bgc     extends ClimateModel { val name = "CESM1-BGC"      }
+  case object Cesm1Cam5    extends ClimateModel { val name = "CESM1-CAM5"     }
+  case object CmccCm       extends ClimateModel { val name = "CMCC-CM"        }
+  case object CmccCms      extends ClimateModel { val name = "CMCC-CMS"       }
+  case object CnrmCm5      extends ClimateModel { val name = "CNRM-CM5"       }
+  case object CsiroMk360   extends ClimateModel { val name = "CSIRO-Mk3-6-0"  }
+  case object EcEarth      extends ClimateModel { val name = "EC-EARTH"       }
+  case object FGoalsG2     extends ClimateModel { val name = "FGOALS-g2"      }
+  case object GfdlCm3      extends ClimateModel { val name = "GFDL-CM3"       }
+  case object GfdlEsm2G    extends ClimateModel { val name = "GFDL-ESM2G"     }
+  case object GfdlEsm2M    extends ClimateModel { val name = "GFDL-ESM2M"     }
+  case object GissE2H      extends ClimateModel { val name = "GISS-E2-H"      }
+  case object GissE2R      extends ClimateModel { val name = "GISS-E2-R"      }
+  case object HadGem2Ao    extends ClimateModel { val name = "HadGEM2-AO"     }
+  case object HadGem2Cc    extends ClimateModel { val name = "HadGEM2-CC"     }
+  case object HadGem2Es    extends ClimateModel { val name = "HadGEM2-ES"     }
+  case object Inmcm4       extends ClimateModel { val name = "inmcm4"         }
+  case object IpslCm5ALr   extends ClimateModel { val name = "IPSL-CM5A-LR"   }
+  case object IpslCm5AMr   extends ClimateModel { val name = "IPSL-CM5A-MR"   }
+  case object Miroc5       extends ClimateModel { val name = "MIROC5"         }
+  case object MirocEsm     extends ClimateModel { val name = "MIROC-ESM"      }
+  case object MirocEsmChem extends ClimateModel { val name = "MIROC-ESM-CHEM" }
+  case object MpiEsmLr     extends ClimateModel { val name = "MPI-ESM-LR"     }
+  case object MpiEsmMr     extends ClimateModel { val name = "MPI-ESM-MR"     }
+  case object MriCgcm3     extends ClimateModel { val name = "MRI-CGCM3"      }
+  case object NorEsm1M     extends ClimateModel { val name = "NorESM1-M"      }
 
   def unapply(str: String): Option[ClimateModel] = options.find(_.name == str)
 

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Dataset.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Dataset.scala
@@ -4,21 +4,63 @@ import java.net.URI
 
 import ca.mrvisser.sealerate
 import io.circe.Encoder
-import io.temperate.datamodel.ClimateModel._
+import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.raster.RasterExtent
+import geotrellis.vector._
+import _root_.io.temperate.datamodel.ClimateModel._
+import _root_.io.temperate.datamodel.Scenario._
 
 sealed trait Dataset extends Ordered[Dataset] {
+  // Unique, computer readable identifier for this Dataset
   def name: String
+
+  // Short human readable description for this Dataset
   def label: String
+
+  // Long human readable description for this Dataset
   def description: String
+
+  // URL to information about this Dataset
   def url: URI
 
-  def resolution: Double
+  // The CRS of the data in the NetCDF files
+  def crs: CRS
+
+  // The extent of the data in the NetCDF files
+  def extent: Extent
+
+  // The size of the x dimension in the NetCDF files
+  def xSize: Int
+
+  // The size of the y dimension in the NetCDF files
+  def ySize: Int
 
   def models: Set[ClimateModel]
 
-  def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI
+  def compare(that: Dataset): Int = {
+    this.name.compare(that.name)
+  }
 
-  def compare(that: Dataset): Int = { this.name.compare(that.name) }
+  def netCdfFileFor(model: ClimateModel, scenario: Scenario, variable: Variable, year: Int): URI
+
+  def projectedExtent = ProjectedExtent(extent, crs)
+
+  def gridPointForLatLng(point: Point): (Int, Int) = gridPointForLatLng(point.getX, point.getY)
+
+  def gridPointForLatLng(lon: Double, lat: Double): (Int, Int)
+
+  protected def rasterExtent = RasterExtent(extent, xSize, ySize)
+
+  // The greatest common divisor for xSize and ySize
+  // This is used downstream in order to construct TileLayouts that maintain a one-to-one mapping
+  // of tile pixel to original NetCDF pixel. If we don't use integer divisions we potentially
+  // introduce pixel interpolation of the original data.
+  def pixelGcd: Int = {
+    def gcd(a: Int, b: Int): Int = {
+      if (b == 0) a else gcd(b, a % b)
+    }
+    gcd(xSize, ySize)
+  }
 }
 
 object Dataset {
@@ -33,8 +75,11 @@ object Dataset {
       "precipitation for every 6x6km (1/16th degree resolution) for the conterminous US from 1950 to 2100. LOCA " +
       "attempts to better preserve extreme hot days, heavy rain events and regional patterns of precipitation. The " +
       "total dataset size is approximately 10 TB."
-    val url: URI           = URI.create("http://loca.ucsd.edu/")
-    val resolution: Double = 0.0625
+    val url: URI = URI.create("http://loca.ucsd.edu/")
+    val crs      = LatLng
+    val extent   = Extent(-126.0, 23.4, -66.0, 54.0)
+    val xSize    = 960
+    val ySize    = 490
 
     val models: Set[ClimateModel] = Set[ClimateModel](
       Access10,
@@ -71,11 +116,42 @@ object Dataset {
       NorEsm1M
     )
 
-    def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI = {
+    // LOCA defines origin point at bottom left of two dimensional grid
+    // e.g. both lon and lat dimensions increases as index does, rather than lat dimension decreasing
+    def gridPointForLatLng(lon: Double, lat: Double): (Int, Int) = {
+      val (x, y) = rasterExtent.mapToGrid(lon, lat)
+      (x, ySize - y)
+    }
+
+    def netCdfFileFor(model: ClimateModel,
+                      scenario: Scenario,
+                      variable: Variable,
+                      year: Int): URI = {
       val scenarioName = scenario.name.toLowerCase
       val variableName = variable.name.toLowerCase
+      val ensembleName = ensemble(model, scenario)
       URI.create(
-        s"https://nasanex.s3.amazonaws.com/LOCA/${model}/16th/${scenarioName}/r6i1p1/${variableName}/${variableName}_day_${model}_${scenarioName}_r6i1p1_${year}0101-${year}1231.LOCA_2016-04-02.16th.nc")
+        s"s3://nasanex/LOCA/${model.name}/16th/${scenarioName}/${ensembleName}/${variableName}/${variableName}_day_${model.name}_${scenarioName}_${ensembleName}_${year.toString}0101-${year.toString}1231.LOCA_2016-04-02.16th.nc")
+    }
+
+    private def ensemble(model: ClimateModel, scenario: Scenario): String = {
+      (scenario, model) match {
+        case (RCP85, Ccsm4)   => "r6i1p1"
+        case (RCP85, EcEarth) => "r2i1p1"
+        case (RCP85, GissE2H) => "r2i1p1"
+        case (RCP85, GissE2R) => "r2i1p1"
+
+        case (RCP45, Ccsm4)   => "r6i1p1"
+        case (RCP45, EcEarth) => "r8i1p1"
+        case (RCP45, GissE2H) => "r6i1p3"
+        case (RCP45, GissE2R) => "r6i1p1"
+
+        case (Historical, Ccsm4)   => "r6i1p1"
+        case (Historical, GissE2H) => "r6i1p1"
+        case (Historical, GissE2R) => "r6i1p1"
+
+        case _ => "r1i1p1"
+      }
     }
   }
 
@@ -94,8 +170,11 @@ object Dataset {
       "using a daily Bias-Correction - Spatial Disaggregation (BCSD) method (Thrasher, et al., 2012). The data spans " +
       "the entire globe with a 0.25 degree (~25-kilometer) spatial resolution for the periods from 1950 through 2005 " +
       "(Historical) and from 2006 to 2100 (Climate Projections)."
-    val url: URI           = URI.create("https://nex.nasa.gov/nex/projects/1356/")
-    val resolution: Double = 0.25
+    val url: URI = URI.create("https://nex.nasa.gov/nex/projects/1356/")
+    val crs      = LatLng
+    val extent   = Extent(-180, -90, 180, 90)
+    val xSize    = 1440
+    val ySize    = 720
 
     val models: Set[ClimateModel] = Set[ClimateModel](
       Access10,
@@ -121,8 +200,17 @@ object Dataset {
       NorEsm1M
     )
 
-    def netCdfFileFor(model: String, scenario: Scenario, variable: Variable, year: String): URI =
-      ???
+    override def gridPointForLatLng(lon: Double, lat: Double): (Int, Int) = ???
+
+    def netCdfFileFor(model: ClimateModel,
+                      scenario: Scenario,
+                      variable: Variable,
+                      year: Int): URI = {
+      val scenarioName = scenario.name.toLowerCase
+      val variableName = variable.name.toLowerCase
+      URI.create(
+        s"s3://nasanex/NEX-GDDP/BCSD/${scenarioName}/day/atmos/${variableName}/r1i1p1/v1.0/${variableName}_day_BCSD_${scenarioName}_r1i1p1_${model.name}_${year.toString}.nc")
+    }
   }
 
   def unapply(str: String): Option[Dataset] = options.find(_.name == str)

--- a/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Scenario.scala
+++ b/src/area-indicators/datamodel/src/main/scala/io/temperate/datamodel/Scenario.scala
@@ -8,6 +8,7 @@ sealed trait Scenario extends Ordered[Scenario] {
   def label: String
   def description: String
   def alias: String
+  def years: Range
 
   def compare(that: Scenario): Int = { this.name.compare(that.name) }
 }
@@ -21,6 +22,7 @@ object Scenario {
       : String = "Stabilization without overshoot pathway to 4.5 W/m2 at stabilization after 2100. See " +
       "https://www.skepticalscience.com/rcp.php"
     val alias: String = "Low emissions"
+    val years         = 2006 to 2100
   }
 
   case object RCP85 extends Scenario {
@@ -30,6 +32,7 @@ object Scenario {
     val description: String = "Rising radiative forcing pathway leading to 8.5 W/m2 in 2100. See " +
       "https://www.skepticalscience.com/rcp.php"
     val alias: String = "High emissions"
+    val years         = 2006 to 2100
   }
 
   case object Historical extends Scenario {
@@ -39,6 +42,7 @@ object Scenario {
     val description =
       "A historical dataset from NEX GDDP for 1950 to 2005 that blends reanalysis data with observations"
     val alias = ""
+    val years = 1950 to 2005
   }
 
   def unapply(str: String): Option[Scenario] = Scenario.options.find(_.name == str)

--- a/src/area-indicators/ingest/src/main/scala/ClimateIngest.scala
+++ b/src/area-indicators/ingest/src/main/scala/ClimateIngest.scala
@@ -1,0 +1,118 @@
+package io.temperate.ingest
+
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.layer._
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.store.s3.S3LayerWriter
+import geotrellis.store._
+import geotrellis.store.s3.S3AttributeStore
+import geotrellis.util._
+import _root_.io.circe.Encoder
+import org.apache.spark.SparkContext
+import ucar.nc2.NetcdfFile
+import _root_.io.temperate.datamodel._
+import geotrellis.store.avro.AvroRecordCodec
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+class ClimateIngest(bucket: String, keyPrefix: String)(@transient implicit val sc: SparkContext)
+    extends Serializable
+    with LazyLogging {
+
+
+  def run(config: ProductionIngestConfig): Unit = {
+    val climateModelCount = config.dataset.models.toSeq.size
+    val variableCount     = Variable.options.toSeq.size
+    val tileCount         = climateModelCount * variableCount
+
+    val bConfig = sc.broadcast(config)
+
+    val keyedTilesRdd =
+      sc.parallelize(config.keys.toSeq, config.keys.size).map { key =>
+        // This is all constant for the entire Key
+        val dateTime     = bConfig.value.timeForKey(key)
+        val spatialKey   = key.getComponent[SpatialKey]
+        val keyExtent    = spatialKey.extent(bConfig.value.layoutDefinition)
+        val minGridPoint = bConfig.value.dataset.gridPointForLatLng(keyExtent.southWest)
+        val maxGridPoint = bConfig.value.dataset.gridPointForLatLng(keyExtent.northEast)
+        val xSize        = math.abs(maxGridPoint._1 - minGridPoint._1)
+        val ySize        = math.abs(maxGridPoint._2 - minGridPoint._2)
+
+        val tileArray = Array.ofDim[Tile](tileCount)
+        val modelVars = for {
+          model    <- bConfig.value.dataset.models
+          variable <- Variable.options
+        } yield (model, variable)
+        assert(modelVars.size == tileCount,
+               s"modelVars.size ${modelVars.size} != tileCount ${tileCount}")
+
+        modelVars.foreach {
+          case (model: ClimateModel, variable: Variable) => {
+            val index = bConfig.value.dataset.tileIndex(model, variable)
+            val uri = bConfig.value.dataset
+              .netCdfFileFor(model, bConfig.value.scenario, variable, dateTime.getYear)
+            tileArray(index) = try {
+              val netcdf = NetcdfFile.open(uri.toString)
+
+              val latVar = netcdf.findVariable("lat")
+              val yShape = latVar.getShape(0)
+              assert(yShape == bConfig.value.dataset.ySize, s"yShape ${yShape} != ySize ${ySize}")
+              val lonVar = netcdf.findVariable("lon")
+              val xShape = lonVar.getShape(0)
+              assert(xShape == bConfig.value.dataset.xSize, s"xShape ${xShape} != xSize ${xSize}")
+
+              val dataVar  = netcdf.findVariable(variable.name.toLowerCase)
+              val ucarType = dataVar.getDataType
+              val nodata = dataVar
+                .findAttributeIgnoreCase("_FillValue")
+                .getValues
+                .getFloat(0)
+
+              val day = dateTime.getDayOfYear - 1 // one to zero indexing
+
+              val origin: Array[Int] = Array(day, minGridPoint._2, minGridPoint._1)
+              val size: Array[Int]   = Array(1, ySize, xSize)
+              logger.info(s"Reading ${key}, ${model.name}, ${variable.name}\n    Origin: ${origin
+                .mkString(", ")}\n    Size:   ${size.mkString(", ")}\n    Extent: ${spatialKey
+                .extent(bConfig.value.layoutDefinition)}\n    NoData: ${nodata}")
+              val data = dataVar
+                .read(origin, size)
+                // TODO: This will have to be handled more generically (likely defined at Dataset trait level) if we
+                //       decide to also ingest GDDP
+                .flip(1) // flip y back because Tile expects origin in top left but LOCA origin is bottom left
+                .get1DJavaArray(ucarType)
+                .asInstanceOf[Array[Float]]
+              netcdf.close()
+              // Different datasets have different nodata values. Massage all to use standard floatNODATA
+              val cleanData = if (nodata != FloatConstantNoDataCellType.noDataValue) {
+                data.map { v =>
+                  if (v == nodata) FloatConstantNoDataCellType.noDataValue else v
+                }
+              } else {
+                data
+              }
+              FloatArrayTile(cleanData, xSize, ySize)
+            } catch {
+              case e: Throwable => {
+                logger.warn(s"Failed to read NetCDF: (${dateTime.toString}) ${uri.toString}")
+                logger.warn(e.getLocalizedMessage)
+
+                FloatConstantTile(floatNODATA, xSize, ySize)
+              }
+            }
+          }
+        }
+        (key, MultibandTile(tileArray))
+      }
+
+    val outputRdd = MultibandTileLayerRDD(keyedTilesRdd, config.tileLayerMetadata)
+
+    val layerName      = s"${config.dataset.name.toLowerCase}-${config.scenario.name.toLowerCase}"
+    val layerId        = LayerId(layerName, 0)
+    val attributeStore = S3AttributeStore(bucket, keyPrefix)
+    val writer         = S3LayerWriter(attributeStore)
+    writer.write(layerId, outputRdd, config.keyIndexMethod)
+  }
+}

--- a/src/area-indicators/ingest/src/main/scala/DayOfYearTuple.scala
+++ b/src/area-indicators/ingest/src/main/scala/DayOfYearTuple.scala
@@ -1,0 +1,18 @@
+package io.temperate.ingest
+
+import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
+
+case class DayOfYearTuple(year: Int, dayOfYear: Int) {
+
+  def toZonedDateTime: Option[ZonedDateTime] = {
+    try {
+      Some(
+        LocalDateTime
+          .of(year, 1, 1, 0, 0)
+          .atZone(ZoneOffset.UTC)
+          .withDayOfYear(dayOfYear))
+    } catch {
+      case _: Throwable => None
+    }
+  }
+}

--- a/src/area-indicators/ingest/src/main/scala/IngestConfig.scala
+++ b/src/area-indicators/ingest/src/main/scala/IngestConfig.scala
@@ -1,0 +1,87 @@
+package io.temperate.ingest
+
+import java.time.ZonedDateTime
+
+import geotrellis.layer._
+import geotrellis.raster.{FloatConstantNoDataCellType, TileLayout}
+import geotrellis.store.avro.AvroRecordCodec
+import geotrellis.store.index.{KeyIndexMethod, ZCurveKeyIndexMethod}
+import geotrellis.vector.Extent
+import geotrellis.util._
+import _root_.io.circe.Encoder
+import io.temperate.datamodel.{Dataset, Scenario}
+
+import scala.reflect.ClassTag
+
+/**
+  * IngestConfig is responsible for abstracting all operations in the ingest
+  * that rely on SpatialKey + TemporalKey.
+  *
+  * We do this so that we can write SpatialKey layers at a single point in time
+  * for debugging. Its way easier to access and visualize layer values via
+  * geotrellis.contrib.vlm.RasterSource, but RasterSource only supports SpatialKey
+  * at this time.
+  */
+abstract class IngestConfig[K: SpatialComponent: AvroRecordCodec: Boundable: Encoder: ClassTag](
+    val dataset: Dataset,
+    val scenario: Scenario)
+    extends Serializable {
+  def extent: Extent
+  def keys: Set[K]
+  def keyIndexMethod: KeyIndexMethod[K]
+  def keyBounds: KeyBounds[K]            = keys.map(k => KeyBounds(k, k)).reduce(_ combine _)
+  def layoutDefinition: LayoutDefinition = LayoutDefinition(extent, tileLayout)
+  def tileLayout: TileLayout
+  def tileLayerMetadata: TileLayerMetadata[K]
+  def timeForKey(key: K): ZonedDateTime
+}
+
+class DebugIngestConfig(dataset: Dataset, scenario: Scenario)
+    extends IngestConfig[SpatialKey](dataset, scenario) {
+  val extent                                          = dataset.extent
+  val gcd                                             = dataset.pixelGcd
+  lazy val keys: Set[SpatialKey]                      = layoutDefinition.mapTransform.keysForGeometry(extent.toPolygon)
+  lazy val keyIndexMethod: KeyIndexMethod[SpatialKey] = ZCurveKeyIndexMethod
+  lazy val tileLayout: TileLayout                     = TileLayout(gcd, gcd, dataset.xSize / gcd, dataset.ySize / gcd)
+  lazy val tileLayerMetadata = TileLayerMetadata[SpatialKey](
+    FloatConstantNoDataCellType,
+    layoutDefinition,
+    extent,
+    dataset.crs,
+    keyBounds
+  )
+
+  def timeForKey(key: SpatialKey): ZonedDateTime = DayOfYearTuple(2020, 1).toZonedDateTime.get
+}
+
+class ProductionIngestConfig(dataset: Dataset, scenario: Scenario)
+    extends IngestConfig[SpaceTimeKey](dataset, scenario) {
+
+  val extent = dataset.extent
+  val gcd    = dataset.pixelGcd
+  lazy val keys: Set[SpaceTimeKey] = {
+    val spatialKeys = layoutDefinition.mapTransform.keysForGeometry(extent.toPolygon)
+    val maybeDateTimes: Iterable[Option[ZonedDateTime]] = for {
+      // TODO #1265: Improve performance such that we can scale up to this
+      // year <- scenario.years
+      year <- Seq(2020)
+      day  <- 1 to 366
+    } yield DayOfYearTuple(year, day).toZonedDateTime
+    val dateTimes = maybeDateTimes.flatten
+    for {
+      spatialKey <- spatialKeys
+      dateTime   <- dateTimes
+    } yield SpaceTimeKey(spatialKey, TemporalKey(dateTime))
+  }
+  lazy val keyIndexMethod: KeyIndexMethod[SpaceTimeKey] = ZCurveKeyIndexMethod.byDay
+  lazy val tileLayout: TileLayout                       = TileLayout(gcd, gcd, dataset.xSize / gcd, dataset.ySize / gcd)
+  lazy val tileLayerMetadata = TileLayerMetadata[SpaceTimeKey](
+    FloatConstantNoDataCellType,
+    layoutDefinition,
+    extent,
+    dataset.crs,
+    keyBounds
+  )
+
+  def timeForKey(key: SpaceTimeKey): ZonedDateTime = key.getComponent[TemporalKey].time
+}

--- a/src/area-indicators/ingest/src/main/scala/Main.scala
+++ b/src/area-indicators/ingest/src/main/scala/Main.scala
@@ -2,32 +2,63 @@ package io.temperate.ingest
 
 import cats.implicits._
 import com.monovore.decline._
+import geotrellis.spark.store.kryo.KryoRegistrator
 import org.apache.spark._
+import org.apache.spark.serializer.KryoSerializer
+import _root_.io.temperate.datamodel.{Dataset, Scenario}
 
 object Main
     extends CommandApp(
       name = "area-indicators-ingest",
       header = "Copy NetCDF Climate Data to GeoTrellis Avro Layers for Area Indicators API",
       main = {
-        val digitsOpt =
-          Opts.option[Int]("digits", short = "d", help = "Digits to calculate").withDefault(1000000)
 
-        val quietOpt = Opts.flag("quiet", help = "Whether to be quiet.").orFalse
+        val outputS3BucketOpt = Opts
+          .argument[String]("outputS3Bucket")
 
-        (digitsOpt, quietOpt).mapN { (digits, quiet) =>
-          val conf = new SparkConf()
-          val sc   = new SparkContext(conf)
-          //your algorithm
-          val n = digits
-          val count = sc
-            .parallelize(1 to n)
-            .map { i =>
-              val x = scala.math.random
-              val y = scala.math.random
-              if (x * x + y * y < 1) 1 else 0
-            }
-            .reduce(_ + _)
-          println("Pi is roughly " + 4.0 * count / n)
+        val outputS3KeyOpt = Opts
+          .argument[String]("outputS3KeyPath")
+
+        val datasetOpt = Opts
+          .option[String]("dataset",
+                          short = "d",
+                          help = "The climate Dataset to run the ingest for")
+          .withDefault("LOCA")
+          .validate(s"dataset must be one of ${Dataset.options.map(_.name).mkString(",")}") {
+            Dataset.unapply(_).isDefined
+          }
+          .map { Dataset.unapply(_).get }
+
+        val scenarioOpt = Opts
+          .option[String]("scenario",
+                          short = "s",
+                          help = "The climate Scenario to run the ingest for")
+          .withDefault("rcp85")
+          .validate(s"scenario must be one of ${Scenario.options.map(_.name).mkString(",")}") {
+            Scenario.unapply(_).isDefined
+          }
+          .map { Scenario.unapply(_).get }
+
+        (outputS3BucketOpt, outputS3KeyOpt, datasetOpt, scenarioOpt).mapN {
+          (bucket, keyPath, dataset, scenario) =>
+            val conf = new SparkConf()
+              .setAppName(s"Temperate Area Indicators ClimateIngest: ${dataset}")
+              .setIfMissing("spark.master", "local[*]")
+              .set("spark.serializer", classOf[KryoSerializer].getName)
+              .set("spark.kryo.registrator", classOf[KryoRegistrator].getName)
+              .set("spark.kryoserializer.buffer.max", "1g")
+
+            // Swap configs here depending on whether you want to write a debug SpatialKey
+            // layer or a production SpaceTimeKey layer. Auto-selection based on a debug
+            // flag got me stuck in compiler hell, so sorry about that.
+            // You'll also need to change the type of the config argument to the
+            // ClimateIngest.run method if you swap these.
+            // val config = new DebugIngestConfig(dataset, scenario)
+            val config = new ProductionIngestConfig(dataset, scenario)
+
+            implicit val sc = new SparkContext(conf)
+            val ingest      = new ClimateIngest(bucket, keyPath)
+            ingest.run(config)
         }
       }
     )

--- a/src/area-indicators/ingest/src/main/scala/methods/ExtraDatasetMethods.scala
+++ b/src/area-indicators/ingest/src/main/scala/methods/ExtraDatasetMethods.scala
@@ -1,0 +1,75 @@
+package io.temperate.ingest.methods
+
+import geotrellis.util.MethodExtensions
+import io.temperate.datamodel._
+import io.temperate.datamodel.ClimateModel._
+
+trait ExtraDatasetMethods extends MethodExtensions[Dataset] {
+
+  def tileIndex(model: ClimateModel, variable: Variable): Int = {
+    val modelIndex = climateModelIndex(model)
+    val varIndex   = variableIndex(variable)
+    modelIndex + varIndex * self.models.size
+  }
+
+  // This method is responsible for determining the order of tiles encoded in the
+  // ingested MultibandTile of geotrellis layer.
+  // If you change the values returned or add/remove entries you'll need to re-run the ingest, otherwise
+  // you'll pull data from the wrong Tile.
+  // This is left as an explicit list to force a pause when changes are made. Returning something like a sorted
+  // list of all options would abstract away the idea that this explicit ordering is critical and allow for
+  // subtle bugs in returning the correct Tile for given model.
+  def climateModelIndex(model: ClimateModel): Int = {
+    if (self == Dataset.Loca) {
+      model match {
+        case Access10     => 0
+        case Access13     => 1
+        case BccCsm11     => 2
+        case BccCsm11M    => 3
+        case CanEsm2      => 4
+        case Ccsm4        => 5
+        case Cesm1Bgc     => 6
+        case Cesm1Cam5    => 7
+        case CmccCm       => 8
+        case CmccCms      => 9
+        case CnrmCm5      => 10
+        case CsiroMk360   => 11
+        case EcEarth      => 12
+        case FGoalsG2     => 13
+        case GfdlCm3      => 14
+        case GfdlEsm2G    => 15
+        case GfdlEsm2M    => 16
+        case GissE2H      => 17
+        case GissE2R      => 18
+        case HadGem2Ao    => 19
+        case HadGem2Cc    => 20
+        case HadGem2Es    => 21
+        case Inmcm4       => 22
+        case IpslCm5ALr   => 23
+        case IpslCm5AMr   => 24
+        case Miroc5       => 25
+        case MirocEsm     => 26
+        case MirocEsmChem => 27
+        case MpiEsmLr     => 28
+        case MpiEsmMr     => 29
+        case MriCgcm3     => 30
+        case NorEsm1M     => 31
+        case _            => throw new IllegalArgumentException(s"${model.name} not found")
+      }
+    } else {
+      throw new IllegalArgumentException(s"${self.name} not supported")
+    }
+  }
+
+  // This method has the same considerations as climateModelIndex above. See comments there for details.
+  // This method is responsible for determining the order of tiles encoded in the output geotrellis layer
+  // If you change the values returned or add/remove entries you'll need to re-run the ingest
+  def variableIndex(variable: Variable): Int = {
+    variable match {
+      case Variable.TasMax => 0
+      case Variable.TasMin => 1
+      case Variable.Precip => 2
+      case _               => throw new IllegalArgumentException(s"${variable.name} not found")
+    }
+  }
+}

--- a/src/area-indicators/ingest/src/main/scala/methods/Implicits.scala
+++ b/src/area-indicators/ingest/src/main/scala/methods/Implicits.scala
@@ -1,0 +1,9 @@
+package io.temperate.ingest.methods
+
+import io.temperate.datamodel.Dataset
+
+object Implicits extends Implicits
+
+trait Implicits {
+  implicit class withExtraDatasetMethods(val self: Dataset) extends ExtraDatasetMethods
+}

--- a/src/area-indicators/ingest/src/main/scala/methods/package.scala
+++ b/src/area-indicators/ingest/src/main/scala/methods/package.scala
@@ -1,0 +1,3 @@
+package io.temperate.ingest
+
+package object methods extends Implicits {}

--- a/src/area-indicators/ingest/src/main/scala/package.scala
+++ b/src/area-indicators/ingest/src/main/scala/package.scala
@@ -1,0 +1,3 @@
+package io.temperate
+
+package object ingest extends methods.Implicits {}

--- a/src/area-indicators/project/Dependencies.scala
+++ b/src/area-indicators/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Versions {
   val CommonsIOVersion         = "2.6"
   val DeclineVersion           = "0.5.0"
   val GeotrellisVersion        = "3.0.0-SNAPSHOT"
-  val GeotrellisContribVersion = "3.16.0"
   val Http4sVersion            = "0.20.3"
+  val JacksonVersion           = "2.6.7"
   val LogbackVersion           = "1.2.3"
   val ScapegoatVersion         = "1.3.8"
   val SealerateVersion         = "0.0.5"
@@ -20,10 +20,9 @@ object Dependencies {
   val circeGeneric          = "io.circe"                    %% "circe-generic"           % Versions.CirceVersion
   val commonsIO             = "commons-io"                  % "commons-io"               % Versions.CommonsIOVersion
   val decline               = "com.monovore"                %% "decline"                 % Versions.DeclineVersion
-  val geotrellisContribGdal = "com.azavea.geotrellis"       %% "geotrellis-contrib-gdal" % Versions.GeotrellisContribVersion
-  val geotrellisContribVlm  = "com.azavea.geotrellis"       %% "geotrellis-contrib-vlm"  % Versions.GeotrellisContribVersion
   val geotrellisRaster      = "org.locationtech.geotrellis" %% "geotrellis-raster"       % Versions.GeotrellisVersion
   val geotrellisS3          = "org.locationtech.geotrellis" %% "geotrellis-s3"           % Versions.GeotrellisVersion
+  val geotrellisS3Spark     = "org.locationtech.geotrellis" %% "geotrellis-s3-spark"     % Versions.GeotrellisVersion
   val geotrellisSpark       = "org.locationtech.geotrellis" %% "geotrellis-spark"        % Versions.GeotrellisVersion
   val geotrellisVector      = "org.locationtech.geotrellis" %% "geotrellis-vector"       % Versions.GeotrellisVersion
   val http4s                = "org.http4s"                  %% "http4s-blaze-server"     % Versions.Http4sVersion
@@ -34,4 +33,11 @@ object Dependencies {
   val sealerate             = "ca.mrvisser"                 %% "sealerate"               % Versions.SealerateVersion
   val sparkCore             = "org.apache.spark"            %% "spark-core"              % Versions.SparkVersion % "provided"
   val specs2Core            = "org.specs2"                  %% "specs2-core"             % Versions.Specs2Version % "test"
+}
+
+object DependencyOverrides {
+  val jacksonCore        = "com.fasterxml.jackson.core"   % "jackson-core"          % Versions.JacksonVersion
+  val jacksonDatabind    = "com.fasterxml.jackson.core"   % "jackson-databind"      % Versions.JacksonVersion
+  val jacksonAnnotations = "com.fasterxml.jackson.core"   % "jackson-annotations"   % Versions.JacksonVersion
+  val jacksonModuleScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.JacksonVersion
 }


### PR DESCRIPTION
## Overview

This PR implements the LOCA ingest, and theoretically all hard requirements for a GDDP ingest, although that dataset remains untested. It also includes an IngestConfig object that abstracts over Key type so that its easy to swap back and forth between debugging SpatialKey based layers and the SpaceTimeKey layers we'll need for the production API.

The test SpaceTimeKey layer is available at `s3://development-us-east-1-climate-data/spacetimekey-2020-test` and contains RCP85 scenario LOCA data for all of 2020. It took 14 hours to run using 8 c5.9xlarge instances at $0.50/hr/instance - ~$60 for compute costs. I don't know what any S3 transfer costs might have been, I can't seem to find the climate account on awsbilling.internal.

TODO:
- [x] Refactor so we can get LazyLogging in there
- [x] Verify we've pulled the correct data and we're generating tiles that are projected/rotated/etc correctly
- [x] Verify decisions regarding writer params, e.g. bilinear
- [x] Verify use of `persist()`

## Demo

![full_tile_two](https://user-images.githubusercontent.com/1818302/63461493-be2e0880-c426-11e9-8f92-d856ed66e391.png)

### Notes

Many iterations on this. The final iteration takes a sequence of SpatialKeys or SpaceTimeKeys and pulls all the data necessary to construct a MultibandTile for the key extent + time for all models and variables in the configured dataset + scenario. The Spark job is entirely S3 IO bound although we're getting consistent 60-80MB/s network IO in a 4 machine m5d.2xlarge cluster such that a job for a single dataset + scenario using SpatialKey for a single time slice completes in ~14 mins. Hopefully the full SpaceTimeKey implementation will scale well.

## Testing Instructions

You can run the ingest by doing:
```
export AWS_PROFILE=planit
export AWS_REGION=us-east-1
./sbt
> project ingest
> sparkSubmit <bucket> <keypath>
```
Which will default to LOCA and RCP85.

Then you can read the entire tile to PNG with the following scala code. You'll have to pull down github.com/geotrellis/geotrellis-contrib and run the code in a console there:
```
cd geotrellis-contrib
export AWS_PROFILE=planit
export AWS_REGION=us-east-1
./sbt
project vlm
console
```
then the code (be sure to update the write path on the last line of the code below before running):
```scala
import geotrellis.raster._
import geotrellis.raster.render._
import geotrellis.store._
import geotrellis.store.s3._
import geotrellis.contrib.vlm.ConvertTargetCellType
import geotrellis.contrib.vlm.avro._

val bucket = "development-us-east-1-climate-data"
val keyPath = "afinkmiller-spatialkey-test-three"
val pngPath = "/path/to/tile.png"

val store = S3AttributeStore(bucket, keyPath)
val layerId = LayerId("loca-rcp85", 0)
val bandCount = 96
val dataPath = GeoTrellisPath(s"s3://${bucket}/${keyPath}", "loca-rcp85", Some(layerId.zoom), Some(bandCount))
val layers = GeotrellisRasterSource.getSourceLayersByName(store, dataPath.layerName, dataPath.bandCount.get)
val rasterSource = new GeotrellisRasterSource(store, dataPath, layers, Some(ConvertTargetCellType(FloatCellType)))
val bands = Seq(0)
val multibandRaster = rasterSource.read(rasterSource.extent).get
val tile = multibandRaster.tile.band(0)
val colorMap = ColorMap.fromQuantileBreaks(tile.histogram, ColorRamps.BlueToRed)
tile.renderPng(colorMap).write(pngPath)
```

Closes #1239 
