### PR TITLE
Remap nginx port to avoid conflict with Robarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ ./scripts/server
 
 ### Nginx vs Angular
 
-By default `./scripts/server` will host the user interface using the Angular server on port 4210. This provides features in development like live refresh on code change. If you want to use Nginx to host on post 8000, you can do so with the `--nginx` flag
+By default `./scripts/server` will host the user interface using the Angular server on port 4210. This provides features in development like live refresh on code change. If you want to use Nginx to host on post 8102, you can do so with the `--nginx` flag
 
 ```bash
 $ vagrant ssh
@@ -166,9 +166,9 @@ yarn start --port 4211
 
 | Port                          | Service                                               |
 | ----------------------------- | ----------------------------------------------------- |
-| [8000](http://localhost:8000) | Nginx                                                 |
 | [8100](http://localhost:8100) | Gunicorn                                              |
 | [8101](http://localhost:8101) | Django debug server                                   |
+| [8102](http://localhost:8102) | Nginx                                                 |
 | [8108](http://localhost:8108) | HTTP4S Area Indicators server                         |
 | [4210](http://localhost:4210) | ng serve                                              |
 | [4210](http://localhost:4211) | ng serve (run from host manually using --port option) |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,14 +34,14 @@ Vagrant.configure(2) do |config|
   # NFS
   config.vm.network "private_network", ip: "192.168.10.100"
 
-  # Nginx
-  config.vm.network :forwarded_port, guest: 8000, host: 8000
-
   # Gunicorn
   config.vm.network :forwarded_port, guest: 8100, host: 8100
 
   # Django debug server
   config.vm.network :forwarded_port, guest: 8101, host: 8101
+
+  # Nginx
+  config.vm.network :forwarded_port, guest: 8102, host: 8102
 
   # Angular
   config.vm.network :forwarded_port, guest: 4210, host: 4210

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     depends_on:
       - django
     ports:
-      - "8000:443"
+      - "8102:443"
     volumes:
       - "./nginx/dist:/var/www"
       - "./nginx/static:/var/static"

--- a/src/area-indicators/api/src/main/scala/io/temperate/api/Server.scala
+++ b/src/area-indicators/api/src/main/scala/io/temperate/api/Server.scala
@@ -19,7 +19,7 @@ object ApiServer extends IOApp {
     allowedOrigins = Set(
       "https://temperate.io",
       "https://staging.temperate.io",
-      "http://localhost:8000",
+      "http://localhost:8102",
       "http://localhost:8108",
       "http://localhost:4210"
     ),

--- a/src/django/planit/settings.py
+++ b/src/django/planit/settings.py
@@ -154,7 +154,7 @@ REST_FRAMEWORK = {
 }
 
 if ENVIRONMENT == 'Development':
-    CORS_ORIGIN_WHITELIST = ('localhost:4210', 'localhost:4211', 'localhost:8000',
+    CORS_ORIGIN_WHITELIST = ('localhost:4210', 'localhost:4211', 'localhost:8102',
                              PLANIT_APP)
 else:
     CORS_ORIGIN_WHITELIST = tuple()


### PR DESCRIPTION
## Overview

Remap nginx port to avoid conflict with Robarts backend. We don't use `nginx` in development that frequently, so it seemed easier to change this than to change the Robarts ports.

### Demo

N/A

## Testing Instructions

 * Follow the instructions in the README to access the application via `nginx`

 - ~[ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~
