### PR TITLE
Fix overlapping modals regression from Angular upgrade

### DIFF
--- a/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.ts
+++ b/src/angular/planit/src/app/assessment/risk-popover/risk-popover.component.ts
@@ -27,7 +27,7 @@ export class RiskPopoverComponent implements OnInit {
   @ViewChild('indicatorModal', {static: true})
   private indicatorModal: ModalTemplateComponent;
 
-  @ViewChild('popover', {static: true})
+  @ViewChild('popover', {static: false})
   private popoverElement: PopoverDirective;
 
   constructor (private indicatorService: IndicatorService,

--- a/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
+++ b/src/angular/planit/src/app/shared/freeform-multiselect/freeform-multiselect.component.ts
@@ -28,7 +28,7 @@ export class FreeformMultiselectComponent implements ControlValueAccessor, OnCha
 
   @Input() public options: string[] = [];
   @Input() public inputId: string = null;
-  @ViewChild('typeahead', {static: true}) typeahead;
+  @ViewChild('typeahead', {static: false}) typeahead;
 
   public selected = '';
   public unsaved = '';


### PR DESCRIPTION
## Overview

Fixes a regression where the indicator data modal could overlap with the modal that triggered it.

While I was at it I grepped through the codebase for any similar issues where should were using `ViewChild(..., {static: true})` incorrectly, and identified one place where a similar console error occurred (though there didn't seem to be any actual regressions caused from that).

## Testing Instructions

 * Follow the steps on #1278 to verify that the bug has been fixed

 - [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1278 
