### PR TITLE
Fix missing city profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!--When making a new release, remember to update the magic links at the bottom.-->
 ## [Unreleased]
+### Added
  - Updated Plan Wizard to allow selecting Organization boundaries
  - Added map page
  - Added County & ClimateAssessmentRegion models/fixtures
+### Fixed
+ - Fixed city profile missing from dashboard
 
 ## [1.10.0] - 2019-09-03
+### Changed
  - Updated Node.js to version 10
  - Updated Angular to version 8
  - The `climate-change-components` library is now a part of this project as the `climate-api` module instead of being installed as an NPM dependency

--- a/src/angular/planit/src/app/core/services/weather-event.service.ts
+++ b/src/angular/planit/src/app/core/services/weather-event.service.ts
@@ -12,7 +12,6 @@ import { CORE_WEATHEREVENTSERVICE_LIST } from '../constants/cache';
 @Injectable()
 export class WeatherEventService {
 
-  private _currentWeatherEvents = new Subject<WeatherEvent[]>();
   private _currentOrgWeatherEvents = new Subject<OrgWeatherEvent[]>();
 
   constructor(private http: HttpClient,
@@ -21,11 +20,7 @@ export class WeatherEventService {
   list(): Observable<WeatherEvent[]> {
     const url = `${environment.apiUrl}/api/weather-event/`;
     const request = this.http.get<WeatherEvent[]>(url);
-    const response = this.cache.get(CORE_WEATHEREVENTSERVICE_LIST, request);
-    response.subscribe(events => {
-      this._currentWeatherEvents.next(events);
-    });
-    return this._currentWeatherEvents.asObservable();
+    return this.cache.get(CORE_WEATHEREVENTSERVICE_LIST, request);
   }
 
   get(weatherEventId: number): Observable<WeatherEvent> {
@@ -41,9 +36,7 @@ export class WeatherEventService {
 
   invalidate() {
     this.cache.clear(CORE_WEATHEREVENTSERVICE_LIST);
-    // Trigger requery and internal push to subjects in list() and
-    // listForCurrentOrg() calls
-    this.list().subscribe(() => undefined);
+    // Trigger requery and internal push to subject
     this.listForCurrentOrg().subscribe(() => undefined);
   }
 


### PR DESCRIPTION
## Overview

Fixes dashboard initialization hanging on a call to `list` weather events, causing the city profile to not appear on dashboard (or other organization information).

Reverts a change from #1277.


### Demo

![image](https://user-images.githubusercontent.com/960264/65537084-94a74780-ded2-11e9-8e6a-01356bafd9e6.png)


### Notes

I simply reverted [this change](https://github.com/azavea/temperate/pull/1277/files#diff-a31eb9c513ea64a6a7cc0d72683d8dbeL21) from adding the plan wizard draw tool. The plan wizard still seems to work fine after reverting, but I'm not sure if I've missed something that led to the change.


## Testing Instructions

 * City profile should load on dashboard page
 * Create plan wizard should still function as expected


 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Fixes #1295 
