### PR TITLE
Add geojson API endpoint for counties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Updated Plan Wizard to allow selecting Organization boundaries
  - Added map page
  - Added County & ClimateAssessmentRegion models/fixtures
+ - Added County GeoJSON API endpoint
 ### Fixed
  - Fixed city profile missing from dashboard
 

--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -51,6 +51,7 @@ router.register(r'weather-event', planit_data_views.WeatherEventViewSet,
 router.register(r'organization-weather-event', planit_data_views.OrganizationWeatherEventViewSet,
                 base_name='organizationweatherevent')
 router.register(r'concern', planit_data_views.ConcernViewSet, base_name='concern')
+router.register(r'counties', planit_data_views.CountyViewSet, base_name='county')
 
 urlpatterns = [
     url(r'^api/climate-api/(?P<route>.*)$',

--- a/src/django/planit_data/serializers.py
+++ b/src/django/planit_data/serializers.py
@@ -1,10 +1,12 @@
 from rest_framework import serializers
 from rest_framework.compat import unicode_to_repr
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from action_steps.serializers import ActionCategoryField
 from planit_data.models import (
     CommunitySystem,
     Concern,
+    County,
     OrganizationAction,
     OrganizationRisk,
     OrganizationWeatherEvent,
@@ -243,3 +245,11 @@ class RelatedAdaptiveValueSerializer(serializers.ModelSerializer):
     class Meta:
         model = RelatedAdaptiveValue
         fields = ('name',)
+
+
+class CountySerializer(GeoFeatureModelSerializer):
+
+    class Meta:
+        model = County
+        geo_field = 'geom'
+        fields = ('name', 'state_fips', 'geoid', 'indicators',)


### PR DESCRIPTION
## Overview

Adds a simple GeoJSON API endpoint to serve counties w/ associated geometries and indicator data.

Results are filtered to the state(s) the users's `primary_organization` is located in, primarily to improve performance when the layer is displayed in a browser.

### Demo

Results on shown on geojson.io:
![geojson io_(iPad Pro)](https://user-images.githubusercontent.com/4432106/65795720-eea94680-e138-11e9-9464-6d5203c855ed.png)


## Testing Instructions

 * `./scripts/update` to load county data if you haven't already done so
 * `curl http://localhost:8100/api/counties/ -H "Authorization: Token ..."

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1290 
