### PR TITLE
Add dashboard minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Added map page
  - Added County & ClimateAssessmentRegion models/fixtures
  - Added County GeoJSON API endpoint
+ - Added mini map to dashboard
 ### Fixed
  - Fixed city profile missing from dashboard
 

--- a/src/angular/planit/src/app/dashboard/city-minimap/city-minimap.component.html
+++ b/src/angular/planit/src/app/dashboard/city-minimap/city-minimap.component.html
@@ -1,0 +1,13 @@
+<div class="aside-block" *ngIf="organization">
+  <div class="aside-content aside-minimap">
+    <app-gmap-static-map
+      [bounds]="organization?.bounds"
+      [latitude]="organization?.location.geometry.coordinates[1]"
+      [longitude]="organization?.location.geometry.coordinates[0]">
+      </app-gmap-static-map>
+    <h3>Organization</h3>
+    <h2 class="text-large">
+      {{ organization?.name || 'Your organization' }}
+    </h2>
+  </div>
+</div>

--- a/src/angular/planit/src/app/dashboard/city-minimap/city-minimap.component.ts
+++ b/src/angular/planit/src/app/dashboard/city-minimap/city-minimap.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+
+import { Observable } from 'rxjs';
+
+import { Organization } from '../../shared/';
+
+@Component({
+  selector: 'app-city-minimap',
+  templateUrl: 'city-minimap.component.html'
+})
+
+export class CityMinimapComponent {
+
+  @Input() public organization: Organization;
+
+  constructor() { }
+}

--- a/src/angular/planit/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/angular/planit/src/app/dashboard/dashboard-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { UserResolve } from '../core/resolvers/user.resolve';
 import { ExpirationGuard } from '../core/services/expiration-guard.service';
 import { PlanAuthGuard } from '../core/services/plan-auth-guard.service';
+import { CityMinimapComponent } from './city-minimap/city-minimap.component';
 import { CityProfileComponent } from './city-profile/city-profile.component';
 import { DashboardComponent } from './dashboard.component';
 import { ReviewPlanComponent } from './review-plan/review-plan.component';
@@ -13,6 +14,11 @@ const routes: Routes = [
     component: DashboardComponent,
     canActivate: [ExpirationGuard, PlanAuthGuard],
     resolve: {user: UserResolve} },
+  {
+    path: 'city-minimap',
+    component: CityMinimapComponent,
+    canActivate: [ExpirationGuard, PlanAuthGuard]
+  },
   {
     path: 'city-profile',
     component: CityProfileComponent,

--- a/src/angular/planit/src/app/dashboard/dashboard.component.html
+++ b/src/angular/planit/src/app/dashboard/dashboard.component.html
@@ -3,11 +3,6 @@
     <header class="page-header">
       <h1 class="page-title-small">{{ organization?.plan_due_date | date: 'yyyy' }} Adaptive Plan</h1>
       <h2 class="page-title-large">Dashboard</h2>
-      <div class="organization-details">
-        {{ organization?.location?.getFullName() || 'Your city' }}
-        <span class="separator"> &bull; </span>
-        {{ organization?.name || 'Your organization' }}
-      </div>
     </header>
 
     <section class="dashboard-container">
@@ -82,6 +77,9 @@
     </section>
 
     <aside class="dashboard-sidebar">
+      <div class="aside-block-container">
+        <app-city-minimap [organization]="organization"></app-city-minimap>
+      </div>
       <div class="aside-block-container">
         <app-city-profile-summary [organization]="organization"></app-city-profile-summary>
       </div>

--- a/src/angular/planit/src/app/dashboard/dashboard.module.ts
+++ b/src/angular/planit/src/app/dashboard/dashboard.module.ts
@@ -16,6 +16,7 @@ import { AssessmentModule } from '../assessment/assessment.module';
 import { SharedModule } from '../shared/shared.module';
 
 import { CheckboxGroupComponent } from './checkbox-group/checkbox-group.component';
+import { CityMinimapComponent } from './city-minimap/city-minimap.component';
 import {
   CityProfileSummaryComponent
 } from './city-profile-summary/city-profile-summary.component';
@@ -47,6 +48,7 @@ import { PlanSummaryComponent } from './review-plan/tabs/plan-summary.component'
   declarations: [
     AdaptationReviewComponent,
     CheckboxGroupComponent,
+    CityMinimapComponent,
     CityProfileComponent,
     CityProfileSummaryComponent,
     DashboardComponent,

--- a/src/angular/planit/src/app/map/map.component.ts
+++ b/src/angular/planit/src/app/map/map.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
 
 import { AgmMap, MapsAPILoader } from '@agm/core';
 import { Polygon } from 'geojson';

--- a/src/angular/planit/src/app/shared/gmap-static-map/gmap-static-map.component.html
+++ b/src/angular/planit/src/app/shared/gmap-static-map/gmap-static-map.component.html
@@ -1,0 +1,4 @@
+<img
+    appGmapStaticMap
+    [src]="srcUrl"
+/>

--- a/src/angular/planit/src/app/shared/gmap-static-map/gmap-static-map.component.ts
+++ b/src/angular/planit/src/app/shared/gmap-static-map/gmap-static-map.component.ts
@@ -1,0 +1,62 @@
+import { HttpParams } from '@angular/common/http';
+import { Component, Input, OnInit, Output } from '@angular/core';
+
+import { Polygon } from 'geojson';
+
+import { environment } from '../../../environments/environment';
+
+
+// zoom level for use with organizations without custom bounds
+const DEFAULT_ZOOM = '10';
+// request static Google map image sized this many pixels, squared
+const IMAGE_SIZE_PX = '200';
+const MAPTYPE = 'roadmap';
+// Google static maps path styling docs:
+// https://developers.google.com/maps/documentation/maps-static/dev-guide#Paths
+// border color is $brand-teal; fill color is $brand-teal-v-light
+const PATH_STYLE = 'weight:3|color:0x46b6ae|fillcolor:0xd3eae9|';
+// round coordiantes to this many decimal places (max used by Google Maps API)
+const ROUND_COORD_PLACES = 6;
+const STATIC_MAP_BASE_URL = 'https://maps.googleapis.com/maps/api/staticmap?';
+
+
+@Component({
+  selector: 'app-gmap-static-map',
+  templateUrl: './gmap-static-map.component.html'
+})
+export class GmapStaticMapComponent implements OnInit {
+
+  @Input() public bounds: Polygon;
+  @Input() public latitude: number;
+  @Input() public longitude: number;
+  @Output() public srcUrl: string = null;
+
+  ngOnInit() {
+    this.setSrcUrl();
+  }
+
+  // build the image source URL to request from the Google static maps API
+  setSrcUrl() {
+    let params = new HttpParams();
+    params = params.set('size', `${IMAGE_SIZE_PX}x${IMAGE_SIZE_PX}`);
+    params = params.set('maptype', MAPTYPE);
+    params = params.set('key', environment.googleMapsApiKey);
+
+    if (this.bounds) {
+      // display bounds as a path
+      const bounds = this.bounds.coordinates[0].reduce((accumulator, coord) => (
+        `${accumulator}${coord[1].toFixed(ROUND_COORD_PLACES)},
+          ${coord[0].toFixed(ROUND_COORD_PLACES)}|`
+      ), PATH_STYLE).slice(0, -1);
+      params = params.set('path', bounds);
+    } else {
+      // center on given point location
+      const center = `${this.latitude.toFixed(ROUND_COORD_PLACES)},
+        ${this.longitude.toFixed(ROUND_COORD_PLACES)}`;
+      params = params.set('center', center);
+      params = params.set('zoom', DEFAULT_ZOOM);
+    }
+
+    this.srcUrl = STATIC_MAP_BASE_URL + params.toString();
+  }
+}

--- a/src/angular/planit/src/app/shared/index.ts
+++ b/src/angular/planit/src/app/shared/index.ts
@@ -53,3 +53,4 @@ export { WizardStepComponent } from './wizard/wizard-step.component';
 
 export { Point } from './geojson';
 export { GmapAutocompleteDirective } from './gmap-autocomplete/gmap-autocomplete.directive';
+export { GmapStaticMapComponent } from './gmap-static-map/gmap-static-map.component';

--- a/src/angular/planit/src/app/shared/shared.module.ts
+++ b/src/angular/planit/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import {
   FreeformMultiselectComponent
 } from './freeform-multiselect/freeform-multiselect.component';
 import { GmapAutocompleteDirective } from './gmap-autocomplete/gmap-autocomplete.directive';
+import { GmapStaticMapComponent } from './gmap-static-map/gmap-static-map.component';
 import { HelpModalComponent } from './help-modal/help-modal.component';
 import { IndicatorChartComponent } from './indicator-chart/indicator-chart.component';
 import { LDProgressbarDirective } from './ldProgressbar/ld-progressbar.directive';
@@ -78,6 +79,7 @@ import { UserEmailsComponent } from './user-emails/user-emails.component';
     ForceCollapseChartContainerComponent,
     FreeformMultiselectComponent,
     GmapAutocompleteDirective,
+    GmapStaticMapComponent,
     HelpModalComponent,
     IndicatorChartComponent,
     LDProgressbarDirective,
@@ -108,6 +110,7 @@ import { UserEmailsComponent } from './user-emails/user-emails.component';
     ForceCollapseChartContainerComponent,
     FreeformMultiselectComponent,
     GmapAutocompleteDirective,
+    GmapStaticMapComponent,
     HelpModalComponent,
     IndicatorChartComponent,
     LDProgressbarDirective,

--- a/src/angular/planit/src/assets/sass/pages/_dashboard.scss
+++ b/src/angular/planit/src/assets/sass/pages/_dashboard.scss
@@ -53,8 +53,31 @@ app-dashboard {
     flex-wrap: wrap;
     justify-content: space-between;
 
+    &.aside-minimap {
+      font-weight: $font-weight-bold;
+      justify-content: center;
+
+      h2 {
+        text-align: center;
+        width: 100%;
+      }
+      h3 {
+        color: $page-title-small-color;
+        text-align: center;
+        text-transform: uppercase;
+        width: 100%;
+      }
+    }
+
     p {
       flex: 1 1 100%;
+    }
+
+    img {
+      align-items: center;
+      flex: 1 1 100%;
+      margin-top: -80px;
+      mask-image: radial-gradient(circle at 50% 50%, white 60%, rgba(0, 0, 0, 0) 60%);
     }
   }
 
@@ -65,7 +88,7 @@ app-dashboard {
       margin-right: 2px;
     }
   }
-  
+
   .nav-tabs {
     display: flex;
   }
@@ -80,7 +103,7 @@ app-dashboard {
   .tab-content {
     padding-bottom: 0;
   }
-  
+
   .tab-assessment {
     padding-bottom: $space-medium;
   }
@@ -93,7 +116,7 @@ app-dashboard {
       th:nth-child(2) {
         width: 40%;
       }
-      
+
       // Hack so that the help icon doesn't get its own line
       @media all and (min-width: 68.125em) and (max-width: 75.188em) {
         th:nth-child(3), th:nth-child(4) {


### PR DESCRIPTION
## Overview

Adds a small static map in a circular mask to the dashboard sidebar.


### Demo

Organization with bounds:
![image](https://user-images.githubusercontent.com/960264/66004256-55e73380-e476-11e9-8169-becc6f9006a2.png)

Organization without bounds:
![image](https://user-images.githubusercontent.com/960264/66004276-6b5c5d80-e476-11e9-927e-f69c718cd40b.png)


## Notes

This uses Google's static maps API, which only requires setting the `src` URL on an `img` element. This should be more efficient than a full map load.

@azavea/temperate-design might want to clean up the styling here a bit.

The circular mask cuts off the attribution text at the bottom of the image. We may need to retain that.


## Testing Instructions

 * Visit dashboard using an organization with custom bounds set
 * Mini map should display at top of dashboard sidebar centered on bounds
 * Visit dashboard using an organization without custom bounds set
 * Mini map should be centered on organization location

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1294
