### PR TITLE
Fix Content-Security-Policy header value

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
 	map $http_x_forwarded_proto $policy {
 		default "";
-		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com 'self'; font-src heapanalytics.com 'self';";
+		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com fonts.googleapis.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com temperate-tiles.s3.amazonaws.com 'self'; font-src heapanalytics.com fonts.gstatic.com 'self';";
 	}
 
 	include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
## Overview

This was blocking loading resources for Google fonts as well as the vector tiles recently added. I noticed this due to the vector tiles not loading, but the issue with Google fonts seems to be long-standing.


### Notes

This header is added by nginx in production environments, and can be tricky to test locally.
I had to make the following changes (to add the header in development and use the development instead of production Google API keys):
```diff
diff --git a/nginx/etc/nginx/nginx.conf b/nginx/etc/nginx/nginx.conf
index 540391a..e7095e3 100644
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -31,8 +31,7 @@ http {
        real_ip_header X-Forwarded-For;
 
        map $http_x_forwarded_proto $policy {
-               default "";
-               https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com fonts.googleapis.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com temperate-tiles.s3.amazonaws.com 'self'; font-src heapanalytics.com fonts.gstatic.com 'self';";
+               default   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com; style-src heapanalytics.com fonts.googleapis.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com temperate-tiles.s3.amazonaws.com 'self'; font-src heapanalytics.com fonts.gstatic.com 'self';";
        }
 
        include /etc/nginx/conf.d/*.conf;
diff --git a/src/angular/planit/src/environments/environment.prod.ts b/src/angular/planit/src/environments/environment.prod.ts
index b236f85..e924e68 100644
--- a/src/angular/planit/src/environments/environment.prod.ts
+++ b/src/angular/planit/src/environments/environment.prod.ts
@@ -8,5 +8,5 @@ export const environment = {
   // as both the Django app and the Angular app are on the same host
   apiUrl: '',
   heapID: '2827494035',
-  googleMapsApiKey: 'AIzaSyDK6j5M8gn7f7aA22hZYOoucyfqwN95tz8',
+  googleMapsApiKey: 'AIzaSyCHvOjXWCRSTVRVMT_t6hBNOp_MFfif754',
 };
```


## Testing Instructions

 * The change is relatively small and the method to test is relatively annoying, so I think it's fine to review this and test the changes on staging after merging.

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?
