### PR TITLE
Don't show related impacts section if there are no related impacts

### DIFF
--- a/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
+++ b/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.html
@@ -24,7 +24,7 @@
       </label>
       <textarea id="impact-description" formControlName="impact_description"></textarea>
     </div>
-    <div class="top-impacts" *ngIf="impacts && risk.weather_event && risk.community_system">
+    <div class="top-impacts" *ngIf="impacts.length > 0 && risk.weather_event && risk.community_system">
       <h3>Effects of {{ risk.title() }}</h3>
       <p>
         Below are some of the effects that {{ risk.weather_event.name | lowercase }} is likely to have on {{ risk.community_system.name | lowercase }},

--- a/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.ts
+++ b/src/angular/planit/src/app/risk-wizard/steps/impact-step/impact-step.component.ts
@@ -37,7 +37,7 @@ export class ImpactStepComponent extends RiskWizardStepComponent<ImpactStepFormM
   public navigationSymbol = '3';
   public risk: Risk;
   public title = 'Potential impact';
-  public impacts: Impact[];
+  public impacts: Impact[] = [];
   public showAllImpacts = false;
   public initialImpactsToShow = 3;
 


### PR DESCRIPTION
## Overview

This is a followup to #1323 
I noticed a bug when testing this on staging - the related impacts section will appear if there are no impacts for the risk - this fixes that.

## Testing Instructions

 * "Groundwater flooding on forestry" has no related impacts (as of now), which is what I used to test this.

 - ~[ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~
