### PR TITLE
Add top impacts section to vulnerability assessment overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Added County GeoJSON API endpoint
  - Added mini map to dashboard
  - Added Impact & related models/fixtures
- - Display related impacts in Risk wizard
+ - Display related impacts in Risk wizard & vulnerability assessment overview
 ### Fixed
  - Fixed city profile missing from dashboard
 

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.html
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.html
@@ -3,18 +3,29 @@
     <header class="page-header" *ngIf="weatherEvent?.name">
       <h1 class="page-title-small">Vulnerability Assessment</h1>
       <h2 class="page-title-large">{{ weatherEvent?.name }}</h2>
-      <p class="paragraph-intro">
-        Based on your chosen top hazards and community systems, we have identified some risks as
-        a high priority to include in your vulnerability assessment.
-      </p>
-      <p>
-        <button class="button-link"
-                [popover]="learnMoreRiskPopover"
-                [outsideClick]="true"
-                container="body"
-                placement="right">Learn how we identify high-priority risks.</button>
+      <p class="paragraph-intro" *ngIf="weatherEvent">
+        Identify how {{ weatherEvent.name | lowercase }} may affect different aspects of your community.
       </p>
     </header>
+    <section class="hazard-impacts" *ngIf="impacts.length > 0">
+      <div class="impact-header">
+        <h3 class="text-small"><strong>Known effects of {{ weatherEvent.name | lowercase }}</strong></h3>
+        <a class="impact-toggle text-small" (click)="impactsShown = !impactsShown">
+          <ng-container *ngIf="impactsShown">Hide <i class="icon icon-chevron-up"></i></ng-container>
+          <ng-container *ngIf="!impactsShown">Show <i class="icon icon-chevron-down"></i></ng-container>
+        </a>
+      </div>
+      <div class="impact-body" *ngIf="impactsShown">
+        <p>
+          Here are some ways in which {{ weatherEvent.name | lowercase }} will affect your area, based on climate data. Keep them in mind as you build your vulnerability assessment.
+        </p>
+        <ul class="impact-list">
+          <li *ngFor="let impact of impacts">
+            {{ impact.tagline ? impact.tagline : impact.label }}
+          </li>
+        </ul>
+      </div>
+    </section>
     <section>
       <va-assessment-overview-table [(risks)]="risks"></va-assessment-overview-table>
       <button class="button" routerLink="risk/new">Add new risk</button>
@@ -28,12 +39,3 @@
     </section>
   </main>
 </div>
-
-<ng-template #learnMoreRiskPopover>
-  <div>
-    These potential risks were selected based on the geographic regions used by the
-    <a href="https://data.globalchange.gov/file/ca9c6f09-9890-41db-ace4-827f9cbeb93a" target="_blank">National Climate Assessment</a>
-    and the potential future climate hazards that are most likely to exist.
-    For more on this, visit our <a routerLink="/methodology">Methodology</a> page.
-  </div>
-</ng-template>

--- a/src/angular/planit/src/app/assessment/assessment-overview.component.ts
+++ b/src/angular/planit/src/app/assessment/assessment-overview.component.ts
@@ -4,8 +4,9 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { Observable } from 'rxjs';
 
+import { ImpactService } from '../core/services/impact.service';
 import { RiskService } from '../core/services/risk.service';
-import { Action, Risk, WeatherEvent } from '../shared';
+import { Action, Impact, Risk, WeatherEvent } from '../shared';
 
 @Component({
   selector: 'va-overview',
@@ -14,9 +15,12 @@ import { Action, Risk, WeatherEvent } from '../shared';
 export class AssessmentOverviewComponent implements OnInit {
 
   public risks: Risk[];
+  public impacts: Impact[] = [];
+  public impactsShown = true;
   public weatherEvent?: WeatherEvent;
 
   constructor (private riskService: RiskService,
+               private impactService: ImpactService,
                private route: ActivatedRoute,
                private router: Router) {}
 
@@ -25,6 +29,8 @@ export class AssessmentOverviewComponent implements OnInit {
       this.weatherEvent = this.route.snapshot.data['weatherEvent'] as WeatherEvent;
       this.riskService.filterByWeatherEvent(this.weatherEvent.id)
         .subscribe(risks => this.risks = risks);
+      this.impactService.rankedFor(this.weatherEvent)
+        .subscribe(impacts => this.impacts = impacts);
     } else {
       this.riskService.list().subscribe(risks => this.risks = risks);
     }

--- a/src/angular/planit/src/assets/sass/pages/_vulnerability-assessment.scss
+++ b/src/angular/planit/src/assets/sass/pages/_vulnerability-assessment.scss
@@ -38,3 +38,35 @@ app-risk-step-review {
     white-space: pre-wrap;
   }
 }
+
+va-overview .hazard-impacts {
+  background: $white;
+  padding: $space-medium $space-large;
+  margin-bottom: $space-xxlarge;
+
+  .impact-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    h3 {
+      margin-bottom: 0;
+      line-height: inherit;
+    }
+    .impact-toggle {
+      cursor: pointer;
+    }
+  }
+  .impact-body {
+    display: flex;
+    flex-direction: row;
+    border-top: 1px solid $neutral-1;
+    padding-top: $space-base;
+    margin-top: $space-base;
+
+    .impact-list {
+      flex: auto;
+      min-width: 60%;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Add top impacts section to vulnerability assessment overview page

### Demo

No impacts:
![localhost_4210_assessment_hazard=3](https://user-images.githubusercontent.com/4432106/68247902-c2ab9b80-ffe9-11e9-806d-cca18d549db3.png)
Several impacts:
![localhost_4210_assessment_hazard=12](https://user-images.githubusercontent.com/4432106/68247903-c3443200-ffe9-11e9-8fb2-f32565d48203.png)
1 impact:
![localhost_4210_assessment_hazard=15](https://user-images.githubusercontent.com/4432106/68247904-c3443200-ffe9-11e9-9c33-2d1c1430f035.png)


### Notes

The section that had been in this location in the vulnerability assessment was not in the recent wireframes, so I removed it. I'm checking with @alexelash that it was intentionally removed.

## Testing Instructions

 * From the dashboard, click "assess" on one of the items in the overview tab to go to that hazard's vulnerability assessment overview

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1308
