### PR TITLE
Fix bugs in impact sorting

### DIFF
--- a/src/angular/planit/src/app/core/services/impact.service.spec.ts
+++ b/src/angular/planit/src/app/core/services/impact.service.spec.ts
@@ -135,4 +135,22 @@ describe('ImpactService', () => {
     const rankedImpacts = service.rankImpacts(impacts, weatherEvent, communitySystem);
     expect(rankedImpacts[0].label).toBe('b');
   }));
+
+  it('should use weather event ranks when missing community system ranks',
+     inject([ImpactService], (service: ImpactService) => {
+    const impacts: Impact[] = [{
+      label: 'a',
+      community_system_ranks: [],
+      weather_event_ranks: [{ weather_event: 1, order: 2 }]
+    }, {
+      label: 'b',
+      community_system_ranks: [],
+      weather_event_ranks: [{ weather_event: 1, order: 1 }]
+    }];
+    const weatherEvent = { id: 1 } as WeatherEvent;
+    const communitySystem = { id: 1 } as CommunitySystem;
+
+    const rankedImpacts = service.rankImpacts(impacts, weatherEvent, communitySystem);
+    expect(rankedImpacts[0].label).toBe('b');
+  }));
 });

--- a/src/angular/planit/src/app/core/services/impact.service.ts
+++ b/src/angular/planit/src/app/core/services/impact.service.ts
@@ -38,20 +38,20 @@ export class ImpactService {
 
     if (communitySystem) {
       rankedImpacts = rankedImpacts.concat(impacts.filter(impact => {
-        return this.getCommunitySystemRank(impact, communitySystem) !== undefined;
+        const hasRank = this.getCommunitySystemRank(impact, communitySystem) !== undefined;
+        return !rankedImpacts.includes(impact) && hasRank;
       }));
     }
 
     rankedImpacts.sort((a, b) => {
       const weatherEventRankA = this.getWeatherEventRank(a, weatherEvent);
       const weatherEventRankB = this.getWeatherEventRank(b, weatherEvent);
-      // Without CS we're guaranteed to have ranks for weather events
-      if (!communitySystem) {
-        return weatherEventRankA.order - weatherEventRankB.order;
-      }
-
       const communitySystemA = this.getCommunitySystemRank(a, communitySystem);
       const communitySystemB = this.getCommunitySystemRank(b, communitySystem);
+
+      if (!communitySystemA && !communitySystemB) {
+        return weatherEventRankA.order - weatherEventRankB.order;
+      }
 
       // Impacts that match both WE & CS are sorted first
       if ((weatherEventRankA && communitySystemA) && !(weatherEventRankB && communitySystemB)) {
@@ -61,7 +61,7 @@ export class ImpactService {
         return 1;
       }
 
-      // If we have both weather events & hazards for each, prefer
+      // If we have both WE & CS for each, prefer
       // weather event ordering over community system
       if (weatherEventRankA && weatherEventRankB && communitySystemA && communitySystemB) {
         if (weatherEventRankA.order !== weatherEventRankB.order) {
@@ -92,6 +92,9 @@ export class ImpactService {
 
   private getCommunitySystemRank(
     impact: Impact, communitySystem: CommunitySystem): ImpactCommunitySystemRank {
+    if (!communitySystem) {
+      return null;
+    }
     return impact.community_system_ranks.find(r => r.community_system === communitySystem.id);
   }
 


### PR DESCRIPTION
## Overview

Noticed 2 bugs in impact sorting when working on my most recent PR
 - When looking at "wildfires on forestry" there was a NPE crash because some impacts only had community system rankings
 - When looking at "wildfires on public health" there were duplicate items in the list

## Testing Instructions

 * On `develop` look at the impact section for the two risks noted above and verify that you can reproduce the issues above
 * On this branch, verify the issues are fixed

 - ~[ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~