### PR TITLE
Add management command to re-geocode existing organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Added Impact & related models/fixtures
  - Display related impacts in Risk wizard & vulnerability assessment overview
  - Switched from Google Places to ESRI geocoder
+ - Added 'geocode_organizations' management command
 ### Fixed
  - Fixed city profile missing from dashboard
 

--- a/src/django/users/management/commands/geocode_organizations.py
+++ b/src/django/users/management/commands/geocode_organizations.py
@@ -1,0 +1,78 @@
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.contrib.gis.geos import Point
+from django.db import transaction
+from django.db.models import Q
+from django.db.utils import IntegrityError
+
+from omgeo import Geocoder
+from omgeo.places import PlaceQuery
+from omgeo.postprocessors import AttrFilter
+from omgeo.services import EsriWGS
+
+from users.models import PlanItOrganization, PlanItLocation
+
+logger = logging.getLogger('planit_data')
+
+
+class Command(BaseCommand):
+    """Used to re-geocode all existing organizations"""
+
+    help = ('Used to re-geocode all existing organizations')
+
+    def handle(self, *args, **options):
+        postprocessors = [AttrFilter(['Locality'], 'locator_type')]
+        postprocessors += EsriWGS.DEFAULT_POSTPROCESSORS[1:]
+        geocoder = Geocoder([('omgeo.services.EsriWGS', {
+            'postprocessors': postprocessors,
+            'settings': {
+                'client_id': settings.ESRI_CLIENT_ID,
+                'client_secret': settings.ESRI_CLIENT_SECRET,
+            }
+        })])
+
+        user_loc_ids = (
+            PlanItOrganization.objects
+            .filter(source=PlanItOrganization.Source.USER)
+            .distinct('location_id')
+            .values_list('location_id', flat=True)
+        )
+        user_locs = (
+            PlanItLocation.objects
+            .exclude(Q(name="") | Q(admin=""))
+            .filter(id__in=user_loc_ids)
+        )
+        deleted_loc_ids = set()
+        for loc in user_locs:
+            if loc.id in deleted_loc_ids:
+                continue
+
+            pq = PlaceQuery(str(loc), for_storage=True)
+            coordinates = geocoder.get_candidates(pq)[0]
+            old_point = loc.point
+            loc.point = Point([coordinates.x, coordinates.y])
+            logger.info("Geocoding for {}, old location '{}', new '{}'".format(loc, old_point,
+                                                                               loc.point))
+            try:
+                loc.save()
+            except IntegrityError:
+                with transaction.atomic():
+                    # If the newly geocoded location conflicts with other locations
+                    # delete them and re-assign their organizations to use this location
+                    conflicting_locations = (
+                        PlanItLocation.objects.filter(name=loc.name, admin=loc.admin)
+                    )
+                    conflicting_ids = {l.id for l in conflicting_locations}
+                    deleted_loc_ids |= conflicting_ids
+
+                    (PlanItOrganization.objects
+                     .filter(location_id__in=conflicting_ids)
+                     .update(location_id=loc.id))
+                    logger.info("Deleting {} duplicate locations for '{}'".format(
+                        len(conflicting_ids), loc))
+                    conflicting_locations.delete()
+
+                    # Should be safe to save now without an IntegrityError
+                    loc.save()


### PR DESCRIPTION
## Overview

Add management command to re-geocode existing organizations using the Esri geocoder. This is needed to allow us to switch away from Google Maps as our mapping library while complying with their terms of service.

### Demo

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/manage geocode_organizations
Geocoding for Philadelphia, PA, old location 'SRID=4326;POINT (-75.16522150000003 39.9525839)', new 'SRID=4326;POINT (-75.16217999999998 39.95222000000007)'                           
Geocoding for Houston, TX, old location 'SRID=4326;POINT (-95.3698028 29.7604267)', new 'SRID=4326;POINT (-95.36967999999996 29.76058000000006)'                                       
Geocoding for Los Angeles, CA, old location 'SRID=4326;POINT (-118.2436849 34.0522342)', new 'SRID=4326;POINT (-118.24532 34.05349000000007)'
```

## Testing Instructions
 * `scripts/manage geocode_organizations`

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?

Closes #1333
