### PR TITLE
Fix geocode_organzation command from null-ing out location fields

### DIFF
--- a/src/django/users/management/commands/geocode_organizations.py
+++ b/src/django/users/management/commands/geocode_organizations.py
@@ -63,6 +63,7 @@ class Command(BaseCommand):
                     # delete them and re-assign their organizations to use this location
                     conflicting_locations = (
                         PlanItLocation.objects.filter(name=loc.name, admin=loc.admin)
+                        .exclude(id=loc.id)
                     )
                     conflicting_ids = {l.id for l in conflicting_locations}
                     deleted_loc_ids |= conflicting_ids


### PR DESCRIPTION
## Overview
After running the `geocode_organizations` on command staging I realized it had null-ed out the location field for several organizations.

I recreated the issue in my environment with the following commands in the Django shell to create some `PlanItLocation`s with the same name but different points:

```
In [0]: from django.contrib.gis.geos import Point

In [1]: PlanItLocation.objects.get(name="Philadelphia", admin="PA").point.coords
Out[1]: (-75.16217999999998, 39.95222000000007)

In [2]: loc = PlanItLocation.objects.create(name="Philadelphia", admin="PA", point=Point(-75.16, 39.95))
Out[2]: <PlanItLocation: Philadelphia, PA>

In [3]: PlanItOrganization.objects.filter(location_id=None).update(location=loc)
```

## Testing Instructions

 * Follow the instructions above to recreate the problem with duplicative `PlanItLocation` objects with different point values
 * Verify that the existing script on `develop` will null the `location` field for those organizations out
 * Follow the instructions above again, but this time run the script on this branch
 * Verify that there are now no organizations with a null `location` field (`PlanItOrganization.objects.filter(location=None)`)

 - ~[ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~
