### PR TITLE
Allow ArcGIS geocoding in CSP

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 
 	map $http_x_forwarded_proto $policy {
 		default "";
-		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com cdn.arcgis.com; style-src heapanalytics.com fonts.googleapis.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com temperate-tiles.s3.amazonaws.com cdn.arcgis.com basemaps.arcgis.com 'self'; font-src heapanalytics.com fonts.gstatic.com 'self';";
+		https   "default-src https: blob: 'unsafe-inline' 'unsafe-eval'; img-src https: 'self' data: heapanalytics.com cdn.arcgis.com; style-src heapanalytics.com fonts.googleapis.com 'self' 'unsafe-inline'; script-src https: 'self' 'unsafe-inline' 'unsafe-eval' cdn.heapanalytics.com heapanalytics.com; connect-src heapanalytics.com temperate-tiles.s3.amazonaws.com cdn.arcgis.com basemaps.arcgis.com geocode.arcgis.com 'self'; font-src heapanalytics.com fonts.gstatic.com 'self';";
 	}
 
 	include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
## Overview

Loosen nginx Content Security Policy restrictions to allow calling the geocoding service.


### Notes

I cannot reproduce the nginx hosting environment for testing any longer. `ngrok` used to serve the purpose, as described in the testing notes on #463, but now the site sends too many requests to get past the login page while accessing the local site via `ngrok`.

Modifying the `nginx.conf` policy to use the same CSP for `default` as for `https`, I can reproduce the initial error, which is then resolved by the change here, but then get another error due to restrictions on the `nginx` configuration (`blocked by CORS policy: Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response`).

It may be best to remove the restrictive CSP altogether, as it has caused repeated issues and cannot be easily tested.


## Testing Instructions

 * (see notes above)

 ~~- [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~~

Fixes #1367.
