### PR TITLE
Use https instead of http geocode endpoint

### DIFF
--- a/src/angular/planit/src/app/core/services/geocoder.service.ts
+++ b/src/angular/planit/src/app/core/services/geocoder.service.ts
@@ -32,7 +32,7 @@ export class GeocoderService {
     const extent = LOCA_EXTENT.join(',');
 
     // tslint:disable-next-line:max-line-length
-    const url = `http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=${input}&f=pjson&category=${categories}&searchExtent=${extent}&countryCode=USA`;
+    const url = `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=${input}&f=pjson&category=${categories}&searchExtent=${extent}&countryCode=USA`;
 
     return this.http.get<SuggestResponse>(url);
   }
@@ -41,7 +41,7 @@ export class GeocoderService {
     return this.getToken().pipe(
       mergeMap(token => {
         // tslint:disable-next-line:max-line-length
-        const url = `http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?magicKey=${suggestion.magicKey}&f=pjson&outFields=PlaceName,RegionAbbr&forStorage=true&token=${token}&countryCode=USA`;
+        const url = `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?magicKey=${suggestion.magicKey}&f=pjson&outFields=PlaceName,RegionAbbr&forStorage=true&token=${token}&countryCode=USA`;
         return this.http.get<GeocoderResponse>(url);
       })
     );


### PR DESCRIPTION
## Overview

Attempt to fix geocoder error on staging:
![image](https://user-images.githubusercontent.com/960264/69760092-9e973200-1131-11ea-81f8-a843cc6baaa4.png)

Follow-up to #1370 (it didn't work), which I think was also necessary, but further requires the calls be made using `https` rather than `http`.


### Notes

Again, I don't know a good way to test the nginx CSP. The testing steps below are simply to confirm that the `https` service also works.


## Testing Instructions

 * Run development server in VM with `./scripts/server`
 * Start creating a new organization at http://localhost:4210/create-organization
 * Geocoder should still suggest place names
 

 ~~- [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~~

Fixes #1367.

