### PR TITLE
Fix CORS header issue in AuthInterceptor

### DIFF
--- a/src/angular/planit/src/app/core/interceptors/AuthInterceptor.ts
+++ b/src/angular/planit/src/app/core/interceptors/AuthInterceptor.ts
@@ -14,7 +14,8 @@ export class AuthInterceptor implements HttpInterceptor {
   constructor(private authService: AuthService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (!this.authService.isAuthenticated() || !req.url.startsWith(environment.apiUrl)) {
+    const isInternalUrl = req.url.startsWith('/') || req.url.startsWith(environment.apiUrl);
+    if (!this.authService.isAuthenticated() || !isInternalUrl) {
       return next.handle(req);
     }
 


### PR DESCRIPTION
The `AuthInterceptor` class was introduced in our upgrade to Angular 8. Previously, all access to the backend API was done through a subclass of the Angular Http service that wrapped all calls with authentication headers.

During our upgrade to Angular 8, we made use of the new Interceptor feature to allow use of the native Http client. We failed to add a check to our new interceptor however, and were adding our internal  authentication token when using external services as well, which I noticed when adding support for the Esri geocoder, as it caused the service to return an error.

This error is caused because we're sending headers with `Access-Control-Request-Headers: authorization` in our `OPTIONS` request. I encountered this in development and solved the issue by altering our `AuthInterceptor` to only add the `Authorization` header for our own
backend:
https://github.com/azavea/temperate/blob/add657ca4ae825ac7fac5d40b7737604efec2c25/src/angular/planit/src/app/core/interceptors/AuthInterceptor.ts#L17-L19

However this check only worked in development, as in production we set `environment.apiUrl` to an empty string and rely upon relative URLs:
https://github.com/azavea/temperate/blob/add657ca4ae825ac7fac5d40b7737604efec2c25/src/angular/planit/src/environments/environment.prod.ts#L9

I've added a check for any relative URLs to catch that case.

Closes #1367