### PR TITLE
Update Esri token endpoint URL to match nginx forwarding rules

### DIFF
--- a/src/angular/planit/src/app/core/services/geocoder.service.ts
+++ b/src/angular/planit/src/app/core/services/geocoder.service.ts
@@ -48,7 +48,7 @@ export class GeocoderService {
   }
 
   private getToken(): Observable<string> {
-    const req = this.http.get<EsriApiToken>(`${environment.apiUrl}/esri-api-token/`)
+    const req = this.http.get<EsriApiToken>(`${environment.apiUrl}/api/esri-api-token/`)
       .pipe(map(response => response.esri_token));
     return this.cache.get(this.ESRI_CLIENT_TOKEN_KEY, req, this.MAX_AGE);
   }

--- a/src/django/planit/urls.py
+++ b/src/django/planit/urls.py
@@ -55,6 +55,8 @@ router.register(r'concern', planit_data_views.ConcernViewSet, base_name='concern
 router.register(r'counties', planit_data_views.CountyViewSet, base_name='county')
 router.register(r'impacts', planit_data_views.ImpactViewSet, base_name='impact')
 
+# NOTE: all URL patterns listed must match one of the prefixes specified in
+# 'nginx/etc/nginx/conf.d/default.conf' in order to function outside of the development setup
 urlpatterns = [
     url(r'^api/climate-api/(?P<route>.*)$',
         ClimateAPIProxyView.as_view(), name='climate-api-proxy'),
@@ -72,8 +74,8 @@ urlpatterns = [
         get_user,
         name='user_from_uid_token'),
     url(r'^api/user/$', CurrentUserView.as_view(), name='current_user'),
+    url(r'^api/esri-api-token/$', EsriGeocoderTokenView.as_view(), name='esri_token'),
     url(r'^api-token-auth/', PlanitObtainAuthToken.as_view(), name='token_auth'),
-    url(r'^esri-api-token/$', EsriGeocoderTokenView.as_view(), name='esri_token'),
 
     # Health check
     url(r'^health-check/', include('watchman.urls')),


### PR DESCRIPTION
## Overview

#1372 fixed the immediate issue on staging, but didn't get the feature fully working, as attempts to get the Esri API token were routed by `nginx` to the Angular front-end instead of Django :expressionless: 

This time around I made sure to test locally using `scripts/server --nginx`, recreate the original issue, and verify my fix worked.

Also adds a note to the `urls.py` file to avoid encountering this particular issue again in the future.

## Testing Instructions

 * `./scripts/update`
 * `./scripts/server --nginx`
 * Create an organization, verifying that the location search works as expected and that there are no console errors

 - ~[ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?~

Closes #1367 