### PR TITLE
Update pull request template checklist to include testing the AoT build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,6 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include test case, and expected output
 
  - [ ] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?
+ - [ ] Have you tested any front-end changes using the AoT build (`./scripts/update && ./scripts/server --nginx`)?
 
 Closes #XXX


### PR DESCRIPTION
I'm opening this as a separate PR to spark discussion on whether this is something other folks think would be valuable to add to our PR checklist.

It hasn't been a regular part of my process to test the AoT build of the app served through nginx, though we do have the ability to do so.

In the past this was somewhat annoying, as the Google API is locked down by referrer, and testing the AoT build would also switch to the production Google API key, which is not (and should not) be set up for local testing.

Switching away from the Google Maps API makes local testing of the AoT build easier. We've been bitten enough times by things working in development but not on staging, that I think it is worth the time spent to add this to our checklist.