### PR TITLE
Show toggleable county layer on organization creation map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Display related impacts in Risk wizard & vulnerability assessment overview
  - Switched from Google Places to ESRI geocoder
  - Added 'geocode_organizations' management command
- - Added tribal areas layer to the organization area map
+ - Added tribal areas and county layers to the organization area map
 ### Fixed
  - Fixed city profile missing from dashboard
 

--- a/src/angular/planit/src/app/create-plan/plan-wizard/steps/area-step/area-step.component.html
+++ b/src/angular/planit/src/app/create-plan/plan-wizard/steps/area-step/area-step.component.html
@@ -61,11 +61,19 @@
             [ngModelOptions]="{standalone: true}"/>
           Show tribal areas
         </label>
+        <label>
+          <input
+            name="countiesToggle"
+            type="checkbox"
+            [(ngModel)]="showCounties"
+            [ngModelOptions]="{standalone: true}"/>
+          Show counties
+        </label>
       </div>
-      <div #tribalNamePopup
-        class="tribal-name-popup"
-        [hidden]="!showTribalLabel">
-        <p *ngFor="let name of tribalAreaNames">{{name}}</p>
+      <div #overlayPopup
+        class="overlay-popup"
+        [hidden]="!showOverlayLabel">
+        <p *ngFor="let name of areaNames">{{name}}</p>
       </div>
       <div class="map-container">
         <aol-map>
@@ -81,7 +89,7 @@
           <aol-interaction-translate
             *ngIf="polygon"
             [layers]="canDrag"
-            (translating)="checkPolygon()">
+            (translating)="onTranslating()">
           </aol-interaction-translate>
 
           <aol-view [zoom]="12">
@@ -90,7 +98,7 @@
               [x]="initialLocation.geometry.coordinates[0]"
               [srid]="wgs84"></aol-coordinate>
           </aol-view>
-          <aol-layer-vector [zIndex]="2" #bounds>
+          <aol-layer-vector [zIndex]="4" #bounds>
             <aol-source-vector>
             </aol-source-vector>
           </aol-layer-vector>
@@ -99,11 +107,24 @@
             [renderMode]="'hybrid'"
             [renderBuffer]="5"
             [style]="styleTribalFeature"
-            [zIndex]="1">
+            [zIndex]="2">
             <aol-source-vectortile
               [url]="tribalAreasVectorUri">
               <aol-format-mvt></aol-format-mvt>
-              <aol-tilegrid></aol-tilegrid>
+              <aol-tilegrid [maxZoom]="14"></aol-tilegrid>
+            </aol-source-vectortile>
+          </aol-layer-vectortile>
+          <aol-layer-vectortile
+            *ngIf="showCounties"
+            [renderMode]="'hybrid'"
+            [renderBuffer]="5"
+            [opacity]="0.5"
+            [style]="styleCountyFeature"
+            [zIndex]="1">
+            <aol-source-vectortile
+              [url]="countiesVectorUri">
+              <aol-format-mvt></aol-format-mvt>
+              <aol-tilegrid [maxZoom]="7"></aol-tilegrid>
             </aol-source-vectortile>
           </aol-layer-vectortile>
         </aol-map>


### PR DESCRIPTION
## Overview

Builds on top of the work done in #1368 to also add a county layer to the same map

### Demo


![image](https://user-images.githubusercontent.com/4432106/70267064-ad05cf00-176b-11ea-833c-de193f24d8ac.png)


### Notes

 - I made the county layer transparent so the basemap could still be seen, but I left the tribal areas layer as opaque, since they are smaller and don't cover everything the way counties do. I made sure to change the z-indexes for every layer on the map so that they stack in the following order:
   - basemap
   - counties
   - tribal areas
   - basemap labels
   - user-drawn area


## Testing Instructions

 * http://localhost:4210/plan

 - [x] Is the CHANGELOG.md updated with any relevant additions, changes, fixes or removals following the format of [keepachangelog](https://keepachangelog.com/en/1.0.0/)?
 - [x] Have you tested any front-end changes using the AoT build (`./scripts/update && ./scripts/server --nginx`)?

Closes #1300 