### PR TITLE
New postgres image and postgres 13 with postgis3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '2.3'
 services:
   database:
-    image: quay.io/azavea/postgis:2.2-postgres9.5-slim
+    image: postgis/postgis:13-3.1
     environment:
       - POSTGRES_USER=planit
       - POSTGRES_PASSWORD=planit
       - POSTGRES_DB=planit
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "planit"]
+      test: "pg_isready -h database -U planit"
       interval: 3s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
This is the version we've been mostly standardizing on. (Same versions that are in Debian stable)

Temperate has already been running these in production for a while now - having it work on Jenkins required a new build.